### PR TITLE
Adds context summary

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,4 @@
 ^[.]?air[.]toml$
 ^\.vscode$
 ^\.claude$
+README.html

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,3 +21,4 @@
 ^CRAN-SUBMISSION$
 ^[.]?air[.]toml$
 ^\.vscode$
+^\.claude$

--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+settings.local.json

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,98 @@
+## R package development
+
+### Key commands
+
+```R
+# To run code
+devtools::load_all(); code
+
+# To run all tests
+devtools::test()
+
+# To run all tests for files starting with {name}
+devtools::test(filter = '^{name}')
+
+# To run all tests for R/{name}.R
+devtools::test_active_file('R/{name}.R')
+
+# To run a single test "blah" for R/{name}.R
+devtools::test_active_file('R/{name}.R', desc = 'blah')
+
+# To redocument the package
+devtools::document()
+
+# To check pkgdown documentation
+pkgdown::check_pkgdown()
+
+# To check the package with R CMD check
+devtools::check()
+```
+
+You have two options to run R code:
+
+* `Rscript --no-environ  -e "code"`. 
+
+  Without `--no-environ`, every R call fails with `"Fatal error: cannot create 'R_TempDir'"` because the sandbox blocks reads of `~/.Renviron`, which R reads during startup before creating `tempdir()`.
+
+* If the mcp-repl tool is available, you can use it instead. Note that its default sandbox blocks network requests. 
+
+Other commands:
+
+```
+# To format code
+air format .
+```
+
+### Coding
+
+* Always run `air format .` after generating code
+* Use the base pipe operator (`|>`) not the magrittr pipe (`%>%`)
+* Don't use `_$x` or `_$[["x"]]` since this package must work on R 4.1.
+* Use `\() ...` for single-line anonymous functions. For all other cases, use `function() {...}`
+
+### Testing
+
+- Tests for `R/{name}.R` go in `tests/testthat/test-{name}.R`.
+- All new code should have an accompanying test.
+- If there are existing tests, place new tests next to similar existing tests.
+- Strive to keep your tests minimal with few comments.
+- Never put code in a `test-{name}.R` file outside of a `test_that()` block. Instead, use `tests/testthat/helper.R` or `tests/testthat/helper-{name}.R`.
+- Avoid `expect_true()` and `expect_false()` in favour of a specific expectation which will give a better failure message. A few expectations in newer releases that you might not know about are `expect_all_true()`, `expect_all_equal()`, and `expect_r6_class()`.
+- When testing errors and warnings, don't use `expect_error()` or `expect_warning()`. Instead, use `expect_snapshot(error = TRUE)` for errors and `expect_snapshot()` for warnings because these allow the user to review the full text of the output.
+- Avoid the `.package` argument to `local_mocked_bindings()`; this modifies the namespace of another package which is not good practice. Instead create a mockable version of the function in the current package. See `?local_mocked_bindings` for more details.
+
+### Documentation
+
+- Every user-facing function should be exported and have roxygen2 documentation.
+- Wrap roxygen comments at 80 characters.
+- Internal functions should not have roxygen documentation.
+- Whenever you add a new (non-internal) documentation topic, also add the topic to `_pkgdown.yml`.
+- Always re-document the package after changing a roxygen2 comment.
+- Use `pkgdown::check_pkgdown()` to check that all topics are included in the reference index.
+
+### `NEWS.md`
+
+- Every user-facing change should be given a bullet in `NEWS.md`. 
+- Changes that shouldn't get a bullet:
+    - Small documentation changes.
+    - Internal refactorings. 
+    - Fixes to bugs introduced in the current dev version.
+- Each bullet should briefly describe the change to the end user and mention the related issue in parentheses.
+- A bullet can consist of multiple sentences but should not contain any new lines (i.e. DO NOT line wrap).
+- If the change is related to a function, put the name of the function early in the bullet.
+- Order bullets alphabetically by function name. Put all bullets that don't mention function names at the beginning.
+
+### Writing
+
+- Use sentence case for headings.
+- Use US English.
+
+### Proofreading
+
+If the user asks you to proofread a file, act as an expert proofreader and editor with a deep understanding of clear, engaging, and well-structured writing.
+
+Work paragraph by paragraph, always starting by making a TODO list that includes individual items for each top-level heading.
+
+Fix spelling, grammar, and other minor problems without asking the user. Label any unclear, confusing, or ambiguous sentences with a FIXME comment.
+
+Only report what you have changed.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "defaultMode": "acceptEdits",
+    "allow": [
+      "Bash(air:*)",
+      "Bash(cat:*)",
+      "Bash(find:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr view:*)",
+      "Bash(git checkout:*)",
+      "Bash(git grep:*)",
+      "Bash(grep:*)",
+      "Bash(ls:*)",
+      "Bash(R:*)",
+      "Bash(rm:*)",
+      "Bash(Rscript:*)",
+      "Bash(sed:*)",
+      "Skill",
+      "WebFetch(domain:cran.r-project.org)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)"
+    ],
+    "deny": [
+      "Read(.Renviron)",
+      "Read(.env)"
+    ]
+  }
+}

--- a/.claude/skills/tidy-argument-checking/SKILL.md
+++ b/.claude/skills/tidy-argument-checking/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: types-check
+description: Validate function inputs in R using a standalone file of check_* functions. Use when writing exported R functions that need input validation, reviewing existing validation code, or when creating new input validation helpers.
+---
+
+# Input validation in R functions
+
+This skill describes tidyverse style for validating function inputs. It focuses on rlang's exported type checkers along with the standalone file of `check_*` functions. These functions are carefully designed to produce clear, actionable error messages:
+
+```r
+check_string(123)
+#> Error: `123` must be a single string, not the number 123.
+
+check_number_whole(3.14, min = 1, max = 10)
+#> Error: `3.14` must be a whole number, not the number 3.14.
+```
+
+It assumes that the user has already run `usethis::use_standalone("r-lib/rlang", "types-check")`, and imports rlang in their package. If not, confirm with the user before continuing.
+
+## Function reference
+
+### Scalars (single values)
+
+Use scalar checkers when arguments parameterise the function (configuration flags, names, single counts), rather than represent vectors of user data. They all assert a single value.
+
+- `check_bool()`: Single TRUE/FALSE (use for flags/options)
+- `check_string()`: Single string (allows empty `""` by default)
+- `check_name()`: Single non-empty string (for variable names, symbols as strings)
+- `check_number_whole()`: Single integer-like numeric value
+- `check_number_decimal()`: Single numeric value (allows decimals)
+
+By default, scalar checkers do _not_ allow `NA` elements (`allow_na = FALSE`). Set `allow_na = TRUE` when missing values are allowed.
+
+With the number checkers you can use `min` and `max` arguments for range validation, and `allow_infinite` (default `TRUE` for decimals, `FALSE` for whole numbers).
+
+### Vectors
+
+- `check_logical()`: Logical vector of any length
+- `check_character()`: Character vector of any length
+- `check_data_frame()`: A data frame object
+
+By default, vector checkers allow `NA` elements (`allow_na = TRUE`). Set `allow_na = FALSE` when missing values are not allowed.
+
+### Optional values: `allow_null`
+
+Use `allow_null = TRUE` when `NULL` represents a valid "no value" state, similar to `Option<T>` in Rust or `T | null` in TypeScript:
+
+```r
+# NULL means "use default timeout"
+check_number_decimal(timeout, allow_null = TRUE)
+```
+
+The tidyverse style guide recommends using `NULL` defaults instead of `missing()` defaults, so this pattern comes up often in practice.
+
+## Other helpers
+
+These functions are exported by rlang.
+
+- `arg_match()`: Validates enumerated choices. Use when an argument must be one of a known set of strings.
+
+  ```r
+  # Validates and returns the matched value
+  my_plot <- function(color = c("red", "green", "blue")) {
+  color <- rlang::arg_match(color)
+  # ...
+  }
+
+  my_plot("redd")
+  #> Error in `my_plot()`:
+  #> ! `color` must be one of "red", "green", or "blue", not "redd".
+  #> ℹ Did you mean "red"?
+  ```
+
+  Note that partial matching is an error, unlike `base::match.arg()`. 
+
+- `check_exclusive()` ensures only one of two arguments can be supplied. Supplying both together (i.e. both of them are non-`NULL`) is an error. Use `.require = FALSE` if both can be omitted.
+
+- `check_required()`: Nice error message if required argument (i.e. can't be `missing()`) is not supplied.
+
+## `call` and `arg` arguments
+
+All check functions have `call` and `arg` arguments, but you should never use these unless you are creating your own `check_` function (see below for more details).
+
+## When to validate inputs
+
+**Validate at entry points, not everywhere.**
+
+Input validation should happen at the boundary between user code and your package's internal implementation:
+
+- **Exported functions**: Functions users call directly
+- **Functions accepting user data**: Even internal functions if they directly consume user input, or external data (e.g. unserialised data)
+
+Once inputs are validated at these entry points, internal helper functions can trust the data they receive without checking again.
+
+A good analogy to keep in mind is gradual typing. Think of input validation like TypeScript type guards. Once you've validated data at the boundary, you can treat it as "typed" within your internal functions. Additional runtime checks are not needed. The entry point validates once, and all downstream code benefits.
+
+Exception: Validate when in doubt. Do validate in internal functions if:
+- The cost of invalid data is high (data corruption, security issues)
+- The function or context is complex and you want defensive checks
+
+Example of validating arguments of an exported function:
+
+```r
+# Exported function: VALIDATE
+#' @export
+create_report <- function(title, n_rows) {
+  check_string(title)
+  check_number_whole(n_rows, min = 1)
+
+  # Now call helpers with validated data
+  data <- generate_data(n_rows)
+  format_report(title, data)
+}
+```
+
+Once data is validated at the entry point, internal helpers can skip validation:
+
+```r
+# Internal helper: NO VALIDATION NEEDED
+generate_data <- function(n_rows) {
+  # n_rows is already validated, just use it
+  data.frame(
+    id = seq_len(n_rows),
+    value = rnorm(n_rows)
+  )
+}
+
+# Internal helper: NO VALIDATION NEEDED
+format_report <- function(title, data) {
+  # title and data are already validated, just use them
+  list(
+    title = title,
+    summary = summary(data),
+    rows = nrow(data)
+  )
+}
+```
+
+Note how the `data` generated by `generate_data()` doesn't need validation either. Internal code creating data in a trusted way (e.g. because it's simple or because it's covered by unit tests) doesn't require internal checks.
+
+## Early input checking
+
+Always validate inputs at the start of user-facing functions, before doing any work:
+
+```r
+my_function <- function(x, name, env = caller_env()) {
+  check_logical(x)
+  check_name(name)
+  check_environment(env)
+
+  # ... function body
+}
+```
+
+Benefits:
+
+- This self-documents the types of the arguments
+- Eager evaluation also reduces the risk of confusing lazy evaluation effects
+
+## Custom validation functions
+
+Most packages will need one or more unique checker functions. Sometimes it's sufficient to wrap existing check functions with custom arguments. In this case you just need to carefully pass through the `arg` and `call` arguments. In other cases, you want a completely new check in which case you can call `stop_input_type` with your own arguments.
+
+### Wrapping existing `check_` functions
+
+When creating a wrapper or helper function that calls `check_*` functions on behalf of another function, you **must** propagate the caller context. Otherwise, errors will point to your wrapper function instead of the actual entry point.
+
+Without proper propagation, error messages show the wrong function and argument names:
+
+```r
+# WRONG: errors will point to check_positive's definition
+check_positive <- function(x) {
+  check_number_whole(x, min = 1)
+}
+
+my_function <- function(count) {
+  check_positive(count)
+}
+
+my_function(-5)
+#> Error in `check_positive()`:  # Wrong! Should say `my_function()`
+#> ! `x` must be a whole number larger than or equal to 1.  # Wrong! Should say `count`
+```
+
+With proper propagation, errors correctly identify the entry point and argument:
+
+```r
+# CORRECT: propagates context from the entry point
+check_positive <- function(x, arg = caller_arg(x), call = caller_env()) {
+  check_number_whole(x, min = 1, arg = arg, call = call)
+}
+
+my_function <- function(count) {
+  check_positive(count)
+}
+
+my_function(-5)
+#> Error in `my_function()`:  # Correct!
+#> ! `count` must be a whole number larger than or equal to 1.  # Correct!
+```
+
+Note how `arg` and `call` are part of the function signature. That allows them to be wrapped again by another checking function that can pass down its own context.
+
+### Creating a new `check_` function
+
+When constructing your own `check_` function you can call `stop_input_type()` to take advantage of the existing infrastructure for generating error messages.
+For example, imagine we wanted to create a function that checked that the input was a single date:
+
+```R
+check_date <- function(x, ..., allow_null = FALSE, arg = caller_arg(x), call = caller_env()) {
+  if (!missing(x) && is.Date(x) && length(x) == 1) {
+    return(invisible())
+  }
+
+  stop_input_type(
+    x,
+    "a single Date",
+    ...,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+```
+
+Note you must always check first that the input is not missing, as `stop_input_type()` handles this case specially.
+
+Sometimes you want to check if something is a compound type:
+
+```R
+check_string_or_bool <- function(x, ..., arg = caller_arg(x), call = caller_env()) {
+  if (!missing(x)) {
+    if (is_string(x) || isTRUE(x) || isFALSE(x)) {
+      return(invisible())
+    }
+  }
+
+  stop_input_type(
+    x, 
+    c("a string", "TRUE", "FALSE"),
+    ...,
+    arg = arg,
+    call = call
+  )
+}
+```
+
+Note that the second argument to `stop_input_type()` can take a vector, and it will automatically places commas and "and" in the appropriate locations.
+
+Generally, you should place this `check_` function close to the function that is usually used to construct the object being checked (e.g. close to the S3/S4/S7 constructor.)

--- a/.claude/skills/tidy-deprecate-function/SKILL.md
+++ b/.claude/skills/tidy-deprecate-function/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: tidy-deprecate-function
+description: Guide for deprecating R functions/arguments. Use when a user asks to deprecate a function or parameter, including adding lifecycle warnings, updating documentation, adding NEWS entries, and updating tests.
+---
+
+# Deprecate functions and function arguments
+
+Use this skill when deprecating functions or function parameters in this package.
+
+## Overview
+
+This skill guides you through the complete process of deprecating a function or parameter, ensuring all necessary changes are made consistently:
+
+1. Add deprecation warning using `lifecycle::deprecate_warn()`.
+2. Silence deprecation warnings in existing tests.
+3. Add lifecycle badge to documentation.
+4. Add bullet point to NEWS.md.
+5. Create test for deprecation warning.
+
+## Workflow
+
+### Step 1: Determine deprecation version
+
+Read the current version from DESCRIPTION and calculate the deprecation version:
+
+- Current version format: `MAJOR.MINOR.PATCH.9000` (development).
+- Deprecation version: Next minor release `MAJOR.(MINOR+1).0`.
+- Example: If current version is `2.5.1.9000`, deprecation version is `2.6.0`.
+
+### Step 2: Add `lifecycle::deprecate_warn()` call
+
+Add the deprecation warning to the function:
+
+```r
+# For a deprecated function:
+function_name <- function(...) {
+  lifecycle::deprecate_warn("X.Y.0", "function_name()", "replacement_function()")
+  # rest of function
+}
+
+# For a deprecated parameter:
+function_name <- function(param1, deprecated_param = deprecated()) {
+  if (lifecycle::is_present(deprecated_param)) {
+    lifecycle::deprecate_warn("X.Y.0", "function_name(deprecated_param)")
+  }
+  # rest of function
+}
+```
+
+Key points:
+
+- First argument is the deprecation version string (e.g., "2.6.0").
+- Second argument describes what is deprecated (e.g., "function_name(param)").
+- Optional third argument suggests replacement.
+- Use `lifecycle::is_present()` to check if a deprecated parameter was supplied.
+
+### Step 3: Update tests
+
+Find all existing tests that use the deprecated function or parameter and silence lifecycle warnings. Add at the beginning of test blocks that use the deprecated feature:
+
+```r
+test_that("existing test with deprecated feature", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
+  # existing test code
+})
+```
+
+Then add a new test to verify the deprecation message in the appropriate test file (usually `tests/testthat/test-{name}.R`):
+
+```r
+test_that("function_name(deprecated_param) is deprecated", {
+  expect_snapshot(. <- function_name(deprecated_param = value))
+})
+```
+
+You'll need to supply any additional arguments to create a valid call.
+
+Then run the tests and verify they pass.
+
+### Step 4: Update documentation
+
+For function deprecation, add to the description section:
+
+```r
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
+#' This function is deprecated. Please use [replacement_function()] instead.
+```
+
+If the documentation does not already contain `@description`, you will need to add it.
+
+For argument deprecation, add to the appropriate `@param` tag:
+
+```r
+#' @param deprecated_param `r lifecycle::badge("deprecated")`
+```
+
+When deprecating a function or parameter in favor of a replacement, add old/new examples to the `@examples` section to help users migrate. These should relace all existing examples.
+
+```r
+#' @examples
+#' # Old:
+#' old_function(arg1, arg2)
+#' # New:
+#' replacement_function(arg1, arg2)
+#'
+#' # Old:
+#' x <- "value"
+#' old_function("prefix", x, "suffix")
+#' # New:
+#' replacement_function("prefix {x} suffix")
+```
+
+Key points:
+
+- Use "# Old:" and "# New:" comments to clearly show the transition.
+- Include 2-3 practical examples covering common use cases.
+- Make examples runnable and self-contained.
+- Show how the new syntax differs from the old.
+
+Then re-document the package.
+
+### Step 5: Add NEWS entry
+
+Add a bullet point to the top of the "# packagename (development version)" section in NEWS.md:
+
+```markdown
+# packagename (development version)
+
+* `function_name(parameter)` is deprecated and will be removed in a future
+  version.
+* `function_name()` is deprecated. Use `replacement_function()` instead.
+```
+
+Place the entry:
+
+- In the lifecycle subsection if it exists, otherwise at the top level under development version.
+- Include the replacement if known.
+- Keep entries concise and actionable.
+
+## Implementation checklist
+
+When deprecating a function or parameter, ensure you:
+
+- [ ] Read DESCRIPTION to determine deprecation version.
+- [ ] Add `lifecycle::deprecate_warn()` call in the function.
+- [ ] Add `withr::local_options(lifecycle_verbosity = "quiet")` to existing tests.
+- [ ] Create new test for deprecation warning using `expect_snapshot()`.
+- [ ] Run tests to verify everything works.
+- [ ] Add lifecycle badge to roxygen documentation.
+- [ ] Add migration examples to `@examples` section (for function deprecation).
+- [ ] Run `devtools::document()` to update documentation.
+- [ ] Add bullet point to NEWS.md.
+- [ ] Run `air format .` to format code.

--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,1 +1,2 @@
 *.html
+planning

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,4 +32,4 @@ Config/testthat/edition: 3
 Config/usethis/last-upkeep: 2025-11-10
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lang
 Title: Translates R Help Documentation using Large Language Models
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: c(
     person("Edgar", "Ruiz", , "edgar@posit.co", role = c("aut", "cre")),
     person("Posit Software, PBC", role = c("cph", "fnd"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,16 @@
+# lang (development version)
+
+## New features
+
+* `lang_use()` and `lang_help()` gain a `context_size` argument (`.context_size`
+  in `lang_use()`). When set, a short summary of the full help page is generated
+  and injected into the translation prompt for every field, giving the LLM
+  consistent terminology across sections. Defaults to `100` words; set to `0`
+  to disable.
+
+## Improvements
+
+* Rd parsing has been rewritten to use a structured intermediate list
+  (`rd_to_list()` / `list_to_rd()`) instead of regex-based text manipulation.
+  This makes translations more reliable and eliminates a class of edge-case
+  formatting errors.

--- a/R/help-shims.R
+++ b/R/help-shims.R
@@ -1,5 +1,9 @@
 .onLoad <- function(libname, pkgname) {
   insert_global_shims(force = TRUE)
+  tryCatch(
+    .lang_env$rs <- callr::r_session$new(wait = FALSE),
+    error = function(e) NULL
+  )
 }
 
 

--- a/R/help-shims.R
+++ b/R/help-shims.R
@@ -9,10 +9,9 @@
 
 #' Drop-in replacements for help and ? functions
 #'
-#' The `?` and `help` functions are replacements for functions of the
-#' same name in the utils package. If the LANG environment variable is not set
-#' to English, it will activate the translation to whatever language LANG is
-#' set to.
+#' The `?` and `help` functions are drop-in replacements for those in the
+#' utils package. They automatically translate help to the language specified
+#' by the `LANG` or `LANGUAGE` environment variables, or by `lang_use()`.
 #'
 #' @param topic A name or character string specifying the help topic.
 #' @param package A name or character string specifying the package in which
@@ -79,7 +78,7 @@ shim_lang_help <- function(topic, package = NULL, ...) {
 shim_lang_question <- function(e1, e2) {
   e1_expr <- substitute(e1)
   # ??foo -- Will not translate
-  # Using `ifelse` because if its not a call, then `e1_expr` cannot be subset
+  # Using `ifelse` because if it's not a call, then `e1_expr` cannot be subset
   is_vague <- ifelse(
     is_call(e1_expr),
     identical(e1_expr[[1]], quote(`?`)),

--- a/R/help-shims.R
+++ b/R/help-shims.R
@@ -76,7 +76,11 @@ shim_lang_question <- function(e1, e2) {
   e1_expr <- substitute(e1)
   # ??foo -- Will not translate
   # Using `ifelse` because if its not a call, then `e1_expr` cannot be subset
-  is_vague <- ifelse(is_call(e1_expr), identical(e1_expr[[1]], quote(`?`)), FALSE)
+  is_vague <- ifelse(
+    is_call(e1_expr),
+    identical(e1_expr[[1]], quote(`?`)),
+    FALSE
+  )
   if (en_lang() | is_vague) {
     # Passing as-is if language is English, or there is a `??` call
     eval(as.call(list(utils::`?`, substitute(e1), substitute(e2))))
@@ -141,7 +145,7 @@ which_lang <- function(lang = NULL, choose = FALSE) {
       if (unique(length(lang) > 1) && is.null(.lang_env$choose)) {
         cli_bullets(
           c(
-            "i" =  "The `LANG` and `LANGUAGE` variables have different values.\n",
+            "i" = "The `LANG` and `LANGUAGE` variables have different values.\n",
             " " = "Will use value of `LANGUAGE`: {.val {env_language}}",
             " " = "{.emph This message will only appear once during your session}"
           )

--- a/R/lang-help.R
+++ b/R/lang-help.R
@@ -12,6 +12,10 @@
 #' @param package The R package to look for the topic, if not provided the
 #' function will attempt to find the topic based on the loaded packages.
 #' @param lang A character vector language to translate the topic to
+#' @param context_size Maximum number of words for the context summary prepended
+#' to every field's translation prompt. Set to `0` to disable context-aware
+#' translation. When `NULL`, the value set via `lang_use()` is used (default
+#' `100`).
 #' @param type Produce "html" or "text" output for the help. It defaults to
 #' `getOption("help_type")`
 #' @returns Original or translated version of the help documentation in the
@@ -30,6 +34,7 @@ lang_help <- function(
   topic,
   package = NULL,
   lang = NULL,
+  context_size = NULL,
   type = getOption("help_type")
 ) {
   lang <- which_lang(lang, choose = TRUE)
@@ -85,7 +90,8 @@ lang_help <- function(
     topic <- path_file(help_path)
     rd_content <- db[[path(topic, ext = "Rd")]]
   }
-  topic_path <- rd_translate(rd_content, lang)
+  context_size <- context_size %||% .lang_env$session[["context_size"]]
+  topic_path <- rd_translate(rd_content, lang, context_size = context_size)
   structure(
     list(
       topic = topic,

--- a/R/lang-help.R
+++ b/R/lang-help.R
@@ -26,10 +26,12 @@
 #' }
 #'
 #' @export
-lang_help <- function(topic,
-                      package = NULL,
-                      lang = NULL,
-                      type = getOption("help_type")) {
+lang_help <- function(
+  topic,
+  package = NULL,
+  lang = NULL,
+  type = getOption("help_type")
+) {
   lang <- which_lang(lang, choose = TRUE)
   if (en_lang(lang)) {
     abort("Language already set to English, use `help()`")

--- a/R/lang-help.R
+++ b/R/lang-help.R
@@ -68,7 +68,10 @@ lang_help <- function(
       ))
     }
   }
-  db <- Rd_db(package)
+  db <- .lang_env$rd_db_cache[[package]] %||%
+    {
+      .lang_env$rd_db_cache[[package]] <- Rd_db(package)
+    }
   rd_content <- db[[path(topic, ext = "Rd")]]
   # If topic cannot be found, it will try and see if the topic is aliased
   # (geom_col is inside geom_bar)

--- a/R/lang-help.R
+++ b/R/lang-help.R
@@ -8,12 +8,12 @@
 #' will be processed, so the help returned will be the original package's
 #' documentation.
 #'
-#' @param topic A character vector of the topic to search for.
+#' @param topic A character string specifying the help topic to translate.
 #' @param package The R package to look for the topic, if not provided the
 #' function will attempt to find the topic based on the loaded packages.
 #' @param lang A character vector language to translate the topic to
-#' @param context_size Maximum number of words for the context summary prepended
-#' to every field's translation prompt. Set to `0` to disable context-aware
+#' @param context_size Maximum number of words for the context summary included
+#' with each translation request. Set to `0` to disable context-aware
 #' translation. When `NULL`, the value set via `lang_use()` is used (default
 #' `100`).
 #' @param type Produce "html" or "text" output for the help. It defaults to

--- a/R/lang-help.R
+++ b/R/lang-help.R
@@ -41,6 +41,24 @@ lang_help <- function(
   if (en_lang(lang)) {
     abort("Language already set to English, use `help()`")
   }
+  rd <- rd_find(topic, package)
+  context_size <- context_size %||% .lang_env$session[["context_size"]]
+  topic_path <- rd_translate(rd$content, lang, context_size = context_size)
+  topic <- rd$topic
+  package <- rd$package
+  structure(
+    list(
+      topic = topic,
+      pkg = package,
+      path = topic_path,
+      stage = "render",
+      type = type
+    ),
+    class = "lang_topic"
+  )
+}
+
+rd_find <- function(topic, package = NULL) {
   if (is.null(package)) {
     # Gets the path to installed help file
     help_path <- as.character(utils::help(topic, help_type = "text"))
@@ -72,10 +90,10 @@ lang_help <- function(
     {
       .lang_env$rd_db_cache[[package]] <- Rd_db(package)
     }
-  rd_content <- db[[path(topic, ext = "Rd")]]
+  content <- db[[path(topic, ext = "Rd")]]
   # If topic cannot be found, it will try and see if the topic is aliased
   # (geom_col is inside geom_bar)
-  if (is.null(rd_content)) {
+  if (is.null(content)) {
     # Uses help() to find the actual name of the Rd file that contains
     # the function
     help_path <- as.character(utils::help(
@@ -91,20 +109,9 @@ lang_help <- function(
     }
     # Updates the topic name
     topic <- path_file(help_path)
-    rd_content <- db[[path(topic, ext = "Rd")]]
+    content <- db[[path(topic, ext = "Rd")]]
   }
-  context_size <- context_size %||% .lang_env$session[["context_size"]]
-  topic_path <- rd_translate(rd_content, lang, context_size = context_size)
-  structure(
-    list(
-      topic = topic,
-      pkg = package,
-      path = topic_path,
-      stage = "render",
-      type = type
-    ),
-    class = "lang_topic"
-  )
+  list(topic = topic, package = package, content = content)
 }
 
 #' @export

--- a/R/lang-use.R
+++ b/R/lang-use.R
@@ -5,25 +5,24 @@
 #' converting "english" to "en" for example. The value is passed directly to
 #' the LLM, and it lets the LLM interpret the target language.
 #' @param backend "ollama" or an `ellmer` `Chat` object. If using "ollama",
-#' `mall` will use is out-of-the-box integration with that back-end. Defaults
-#' to "ollama".
+#' `lang` provides built-in support via the `ollamar` package. Defaults to
+#' "ollama".
 #' @param model The name of model supported by the back-end provider
 #' @param ... Additional arguments that this function will pass down to the
 #' integrating function. In the case of Ollama, it will pass those arguments to
 #' `ollamar::chat()`.
-#' @param .cache The path to save model results, so they can be re-used if
-#' the same operation is ran again. To turn off, set this argument to an empty
-#' character: `""`. It defaults to a temp folder. If this argument is left
-#' `NULL` when calling this function, no changes to the path will be made.
+#' @param .cache Character path where translations are cached. Set to `""` to
+#' disable caching. When `NULL`, the current session value is kept unchanged.
+#' Defaults to a temporary folder.
 #' @param .lang Target language to translate to. This will override values found
 #' in the LANG and LANGUAGE environment variables.
-#' @param .context_size Maximum number of words for the context summary that is
-#' prepended to every field's translation prompt. Set to `0` to disable
-#' context-aware translation. Defaults to `100`.
-#' @param .silent Boolean flag that controls if there is or not output to the
+#' @param .context_size Maximum number of words for the context summary
+#' included with each translation request. Set to `0` to disable context-aware
+#' translation. Defaults to `100`.
+#' @param .silent Boolean flag that controls whether there is output to the
 #' console. Defaults to FALSE.
-#' @returns Console output of the current LLM setup to be used during the
-#' R session.
+#' @returns Invisibly returns `NULL`. Prints the current configuration to the
+#' console.
 #'
 #' @examples
 #' \donttest{

--- a/R/lang-use.R
+++ b/R/lang-use.R
@@ -111,10 +111,12 @@ lang_use_impl <- function(
     rs <- .lang_env$rs
     if (!is.null(rs) && rs$is_alive()) {
       if (rs$get_state() == "starting") {
-        rs$poll_process(5000L)
+        rs$poll_process(10000L)
       }
-      lang_rs_refresh(rs)
-      .lang_env$rs_hash <- lang_rs_hash()
+      if (rs$get_state() == "idle") {
+        lang_rs_refresh(rs)
+        .lang_env$rs_hash <- lang_rs_hash()
+      }
     } else {
       lang_rs_get()
     }

--- a/R/lang-use.R
+++ b/R/lang-use.R
@@ -17,6 +17,9 @@
 #' `NULL` when calling this function, no changes to the path will be made.
 #' @param .lang Target language to translate to. This will override values found
 #' in the LANG and LANGUAGE environment variables.
+#' @param .context_size Maximum number of words for the context summary that is
+#' prepended to every field's translation prompt. Set to `0` to disable
+#' context-aware translation. Defaults to `100`.
 #' @param .silent Boolean flag that controls if there is or not output to the
 #' console. Defaults to FALSE.
 #' @returns Console output of the current LLM setup to be used during the
@@ -52,6 +55,7 @@ lang_use <- function(
   model = NULL,
   .cache = NULL,
   .lang = NULL,
+  .context_size = NULL,
   .silent = FALSE,
   ...
 ) {
@@ -61,6 +65,7 @@ lang_use <- function(
     .cache = .cache,
     .is_internal = FALSE,
     .lang = .lang,
+    .context_size = .context_size,
     .silent = .silent,
     ... = ...
   )
@@ -72,6 +77,7 @@ lang_use_impl <- function(
   .cache = NULL,
   .is_internal = FALSE,
   .lang = NULL,
+  .context_size = NULL,
   .silent = FALSE,
   ...
 ) {
@@ -88,6 +94,7 @@ lang_use_impl <- function(
   temp_lang <- tempfile("_lang_cache")
   ca[[".cache"]] <- .cache %||% ca[[".cache"]] %||% temp_lang
   ca[[".lang"]] <- .lang %||% ca[[".lang"]]
+  ca[["context_size"]] <- .context_size %||% ca[["context_size"]] %||% 100L
   if (length(args) > 0) {
     ca[["args"]] <- args
   }

--- a/R/lang-use.R
+++ b/R/lang-use.R
@@ -83,7 +83,7 @@ lang_use_impl <- function(
 ) {
   args <- list(...)
   ca <- .lang_env$session
-  if (!is.null(getOption(".lang_chat"))) {
+  if (!.is_internal && !is.null(getOption(".lang_chat"))) {
     cli_warn(c(
       "Option `.lang_chat` is no longer supported",
       "Use `lang::lang_use([backend])` in your .RProfile file instead"
@@ -104,7 +104,10 @@ lang_use_impl <- function(
   if (.is_internal) {
     return(ca)
   }
-  if (!is.null(ca[["backend"]])) {
+  # Pre-warm the subprocess for string backends (e.g. "ollama", "simulate_llm").
+  # Chat objects are skipped: they can't be serialized to the subprocess and
+  # will be configured lazily on the first help() call via lang_rs_get().
+  if (!is.null(ca[["backend"]]) && !inherits(ca[["backend"]], "Chat")) {
     rs <- .lang_env$rs
     if (!is.null(rs) && rs$is_alive()) {
       if (rs$get_state() == "starting") {

--- a/R/lang-use.R
+++ b/R/lang-use.R
@@ -103,7 +103,20 @@ lang_use_impl <- function(
   model_str <- NULL
   if (.is_internal) {
     return(ca)
-  } else if (!.silent) {
+  }
+  if (!is.null(ca[["backend"]])) {
+    rs <- .lang_env$rs
+    if (!is.null(rs) && rs$is_alive()) {
+      if (rs$get_state() == "starting") {
+        rs$poll_process(5000L)
+      }
+      lang_rs_refresh(rs)
+      .lang_env$rs_hash <- lang_rs_hash()
+    } else {
+      lang_rs_get()
+    }
+  }
+  if (!.silent) {
     backend <- ca[["backend"]]
     if (inherits(backend, "Chat")) {
       provider <- backend$get_provider()

--- a/R/lang.R
+++ b/R/lang.R
@@ -10,3 +10,6 @@
 .lang_env <- new.env()
 .lang_env$session <- list()
 .lang_env$choose <- NULL
+.lang_env$rd_db_cache <- list()
+.lang_env$rs <- NULL
+.lang_env$rs_hash <- NULL

--- a/R/rd-parse.R
+++ b/R/rd-parse.R
@@ -20,8 +20,8 @@
   if (collapse) {
     rd_txt <- paste0(rd_txt, collapse = " ")
   }
-  rd_txt <- gsub("‘", "`", rd_txt)
-  rd_txt <- gsub("’", "`", rd_txt)
+  rd_txt <- gsub("\u2018", "`", rd_txt)
+  rd_txt <- gsub("\u2019", "`", rd_txt)
   rd_txt
 }
 
@@ -36,8 +36,8 @@
   if (is.null(rd_txt) || length(rd_txt) == 0L) {
     return(as.character(x))
   }
-  rd_txt <- gsub("‘", "`", rd_txt)
-  rd_txt <- gsub("’", "`", rd_txt)
+  rd_txt <- gsub("\u2018", "`", rd_txt)
+  rd_txt <- gsub("\u2019", "`", rd_txt)
   if (trim == "tab") {
     tabbed <- substr(rd_txt, 1L, 5L) == "     "
     rd_txt[tabbed] <- substr(rd_txt[tabbed], 6L, nchar(rd_txt[tabbed]))

--- a/R/rd-parse.R
+++ b/R/rd-parse.R
@@ -181,6 +181,84 @@ rd_to_list <- function(rd) {
   do.call(c, keep(map(rd_content, .rd_tag_process), function(x) length(x) > 0))
 }
 
+rd_flatten <- function(lst) {
+  lines <- character()
+  h <- function(tag) lines <<- c(lines, paste0("[[", tag, "]]"))
+  l <- function(...) lines <<- c(lines, paste0(...))
+  br <- function() lines <<- c(lines, "")
+  nms <- names(lst)
+
+  if (!is.null(lst$title)) {
+    h("title")
+    l(lst$title)
+    br()
+  }
+  if (!is.null(lst$description)) {
+    h("description")
+    for (line in lst$description) {
+      l(line)
+    }
+    br()
+  }
+  if (length(lst$arguments)) {
+    for (a in lst$arguments) {
+      l("[[", a$argument, "]]")
+      l(a$description)
+      br()
+    }
+  }
+  if (!is.null(lst$details)) {
+    h("details")
+    for (line in lst$details) {
+      l(line)
+    }
+    br()
+  }
+  if (!is.null(lst$value)) {
+    v <- lst$value
+    if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
+      h("value.intro")
+      l(v$intro)
+      br()
+    }
+    if (length(v$components)) {
+      for (co in v$components) {
+        l("[[", co$component, "]]")
+        l(co$description)
+        br()
+      }
+    }
+    if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
+      h("value.outro")
+      l(v$outro)
+      br()
+    }
+  }
+  sec_items <- lst[nms == "section"]
+  for (i in seq_along(sec_items)) {
+    s <- sec_items[[i]]
+    h(paste0("section.", i, ".title"))
+    l(s$title)
+    br()
+    h(paste0("section.", i, ".body"))
+    for (line in s$contents) {
+      l(line)
+    }
+    br()
+  }
+  for (field in c("author", "references", "seealso")) {
+    vals <- lst[[field]]
+    if (!is.null(vals)) {
+      h(field)
+      for (line in vals) {
+        l(line)
+      }
+      br()
+    }
+  }
+  paste(lines, collapse = "\n")
+}
+
 # Re-encode backtick spans to \code{} and escape bare %.
 .rd_clean <- function(x) {
   x <- gsub("`([^`\n]+)`", "\\\\code{\\1}", x)

--- a/R/rd-parse.R
+++ b/R/rd-parse.R
@@ -1,0 +1,287 @@
+# Render a single Rd node to plain text via Rd2txt().
+.rd_extract_text <- function(x, collapse = TRUE) {
+  rd_tag <- attr(x, "Rd_tag") %||% ""
+  if (rd_tag == "\\dots") {
+    return(" ...")
+  }
+  attributes(x) <- NULL
+  class(x) <- "Rd"
+  rd_text <- if (collapse) {
+    paste0(as.character(x), collapse = "")
+  } else {
+    as.character(x)
+  }
+  tmp <- tempfile(fileext = ".Rd")
+  on.exit(unlink(tmp), add = TRUE)
+  writeLines(rd_text, tmp)
+  old <- options(useFancyQuotes = TRUE)
+  on.exit(options(old), add = TRUE)
+  rd_txt <- suppressWarnings(capture.output(Rd2txt(tmp, fragment = TRUE)))
+  if (collapse) {
+    rd_txt <- paste0(rd_txt, collapse = " ")
+  }
+  rd_txt <- gsub("‘", "`", rd_txt)
+  rd_txt <- gsub("’", "`", rd_txt)
+  rd_txt
+}
+
+# Render a single Rd node to a character vector of lines via Rd2txt().
+.rd_extract_text2 <- function(x, collapse = TRUE, trim = "full") {
+  old <- options(useFancyQuotes = TRUE)
+  on.exit(options(old), add = TRUE)
+  rd_txt <- tryCatch(
+    capture.output(Rd2txt(list(x), fragment = TRUE)),
+    error = function(e) NULL
+  )
+  if (is.null(rd_txt) || length(rd_txt) == 0L) {
+    return(as.character(x))
+  }
+  rd_txt <- gsub("‘", "`", rd_txt)
+  rd_txt <- gsub("’", "`", rd_txt)
+  if (trim == "tab") {
+    tabbed <- substr(rd_txt, 1L, 5L) == "     "
+    rd_txt[tabbed] <- substr(rd_txt[tabbed], 6L, nchar(rd_txt[tabbed]))
+  }
+  if (trim == "full") {
+    rd_txt <- trimws(rd_txt)
+  }
+  rd_txt <- rd_txt[seq(2L, length(rd_txt))]
+  if (length(rd_txt) && rd_txt[[1L]] == "") {
+    rd_txt <- rd_txt[-1L]
+  }
+  if (length(rd_txt) && rd_txt[[length(rd_txt)]] == "") {
+    rd_txt <- rd_txt[-length(rd_txt)]
+  }
+  if (collapse) {
+    rd_txt[rd_txt == ""] <- "xxxx"
+    rd_txt <- paste(rd_txt, collapse = " ")
+    rd_txt <- unlist(strsplit(rd_txt, "xx"))
+  }
+  rd_txt
+}
+
+# Parse \arguments{} items into a list of list(argument, description).
+.rd_args_process <- function(x) {
+  discard(
+    map(x, function(item) {
+      name <- .rd_extract_text(item[1L])
+      val <- .rd_extract_text(item[2L])
+      if (nzchar(name)) {
+        list(argument = name, description = val)
+      } else {
+        NULL
+      }
+    }),
+    is.null
+  )
+}
+
+# Parse \value{} into list(intro, components, outro).
+.rd_value_process <- function(x) {
+  child_tags <- vapply(x, attr, "", "Rd_tag")
+  item_idx <- which(child_tags == "\\item")
+
+  if (length(item_idx) == 0L) {
+    return(list(
+      intro = paste(.rd_extract_text2(x), collapse = "\n"),
+      components = list(),
+      outro = ""
+    ))
+  }
+
+  first_item <- item_idx[[1L]]
+  last_item <- item_idx[[length(item_idx)]]
+
+  render_nodes <- function(nodes) {
+    if (length(nodes) == 0L) {
+      return("")
+    }
+    sub_rd <- nodes
+    class(sub_rd) <- "Rd"
+    txt <- tryCatch(
+      capture.output(Rd2txt(sub_rd, fragment = TRUE)),
+      error = function(e) character(0L)
+    )
+    txt <- txt[nzchar(trimws(txt))]
+    paste(trimws(txt), collapse = " ")
+  }
+
+  intro <- render_nodes(x[seq_len(first_item - 1L)])
+  if (last_item < length(x)) {
+    outro <- render_nodes(x[seq(last_item + 1L, length(x))])
+  } else {
+    outro <- ""
+  }
+
+  components <- discard(
+    map(x[item_idx], function(item) {
+      name <- .rd_extract_text(item[1L])
+      desc <- .rd_extract_text(item[2L])
+      if (nzchar(name)) {
+        list(component = name, description = desc)
+      } else {
+        NULL
+      }
+    }),
+    is.null
+  )
+
+  list(intro = intro, components = components, outro = outro)
+}
+
+# Dispatch per Rd tag; returns a named list fragment.
+.rd_tag_process <- function(x) {
+  out <- list()
+  tag_name <- attr(x, "Rd_tag")
+  x_str <- as.character(x)[[1L]]
+
+  src_prefix <- "% Please edit documentation in "
+  if (grepl(src_prefix, x_str, fixed = TRUE)) {
+    x_str <- substr(x_str, nchar(src_prefix), nchar(x_str))
+    out <- list(source = trimws(x_str))
+  }
+
+  if (grepl("\\\\", tag_name)) {
+    tag_name <- substr(tag_name, 2L, nchar(tag_name))
+    tag_text <- switch(
+      tag_name,
+      "arguments" = list(.rd_args_process(x)),
+      "value" = list(.rd_value_process(x)),
+      "usage" = list(.rd_extract_text2(x, collapse = FALSE, trim = "tab")),
+      "alias" = list(.rd_extract_text(x)),
+      "examples" = {
+        rd_tags <- map_chr(x, attr, "Rd_tag")
+        run <- if ("\\donttest" %in% rd_tags || "\\dontrun" %in% rd_tags) {
+          "code_dont_run"
+        } else {
+          "code_run"
+        }
+        list(set_names(
+          list(trimws(paste0(reduce(map(x, as.character), c), collapse = ""))),
+          run
+        ))
+      },
+      "section" = list(list(
+        title = as.character(x[[1L]]),
+        contents = .rd_extract_text2(x)
+      )),
+      list(.rd_extract_text2(x))
+    )
+    out <- set_names(tag_text, tag_name)
+  }
+  out
+}
+
+rd_to_list <- function(rd) {
+  if (inherits(rd, "Rd")) {
+    rd_content <- rd
+  } else {
+    rd_content <- parse_Rd(rd)
+  }
+  do.call(c, keep(map(rd_content, .rd_tag_process), function(x) length(x) > 0))
+}
+
+# Re-encode backtick spans to \code{} and escape bare %.
+.rd_clean <- function(x) {
+  x <- gsub("`([^`\n]+)`", "\\\\code{\\1}", x)
+  x <- gsub("(?<!\\\\)%", "\\\\%", x, perl = TRUE)
+  x
+}
+
+list_to_rd <- function(lst) {
+  lines <- character()
+  emit <- function(...) lines <<- c(lines, ...)
+  nms <- names(lst)
+
+  emit(sprintf("\\name{%s}", lst$name %||% ""))
+  for (a in unlist(lst[nms == "alias"])) {
+    emit(sprintf("\\alias{%s}", a))
+  }
+  for (kw in unlist(lst[nms == "concept"])) {
+    emit(sprintf("\\concept{%s}", kw))
+  }
+  for (kw in unlist(lst[nms == "keyword"])) {
+    emit(sprintf("\\keyword{%s}", kw))
+  }
+
+  if (!is.null(lst$title)) {
+    emit(sprintf("\\title{%s}", .rd_clean(paste(lst$title, collapse = " "))))
+  }
+  if (!is.null(lst$description)) {
+    emit(
+      "\\description{",
+      .rd_clean(paste(lst$description, collapse = "\n")),
+      "}"
+    )
+  }
+  if (!is.null(lst$usage)) {
+    emit("\\usage{", paste(lst$usage, collapse = "\n"), "}")
+  }
+  if (length(lst$arguments)) {
+    emit("\\arguments{")
+    for (a in lst$arguments) {
+      emit(sprintf(
+        "  \\item{%s}{%s}",
+        a$argument,
+        .rd_clean(paste(a$description, collapse = " "))
+      ))
+    }
+    emit("}")
+  }
+  if (!is.null(lst$details)) {
+    emit("\\details{", .rd_clean(paste(lst$details, collapse = "\n")), "}")
+  }
+  if (!is.null(lst$value)) {
+    v <- lst$value
+    emit("\\value{")
+    if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
+      emit(.rd_clean(v$intro))
+    }
+    for (co in v$components %||% list()) {
+      emit(sprintf(
+        "  \\item{%s}{%s}",
+        co$component,
+        .rd_clean(paste(co$description, collapse = " "))
+      ))
+    }
+    if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
+      emit(.rd_clean(v$outro))
+    }
+    emit("}")
+  }
+  if (!is.null(lst$note)) {
+    emit("\\note{", .rd_clean(paste(lst$note, collapse = "\n")), "}")
+  }
+  for (s in lst[nms == "section"]) {
+    emit(
+      sprintf("\\section{%s}{", .rd_clean(s$title)),
+      .rd_clean(paste(s$contents, collapse = "\n")),
+      "}"
+    )
+  }
+  if (!is.null(lst$author)) {
+    emit("\\author{", .rd_clean(paste(lst$author, collapse = "\n")), "}")
+  }
+  if (!is.null(lst$references)) {
+    emit(
+      "\\references{",
+      .rd_clean(paste(lst$references, collapse = "\n")),
+      "}"
+    )
+  }
+  if (!is.null(lst$seealso)) {
+    emit("\\seealso{", .rd_clean(paste(lst$seealso, collapse = "\n")), "}")
+  }
+  if (!is.null(lst$examples)) {
+    ex <- lst$examples
+    emit("\\examples{")
+    if (!is.null(ex$code_dont_run)) {
+      emit("\\donttest{", ex$code_dont_run, "}")
+    } else if (!is.null(ex$code_run)) {
+      emit(ex$code_run)
+    }
+    emit("}")
+  }
+
+  paste(lines, collapse = "\n")
+}

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -15,7 +15,7 @@ rd_translate <- function(rd_content, lang, context_size) {
     progress_bar_init(
       total = lst_size +
         as.integer(object.size(full_doc_text)) +
-        context_size * 8L,
+        500,
       format = "{pb_bar} {pb_percent} | {tag_label}"
     )
     progress_bar_update_text("Context: Summarizing")
@@ -29,8 +29,7 @@ rd_translate <- function(rd_content, lang, context_size) {
       function(x, lang) mall::llm_vec_translate(x, language = lang),
       args = list(x = summary_en, lang = lang)
     )
-    progress_bar_update_done(context_summary)
-    progress_bar_update_text("Translating...")
+    progress_bar_update_done(500)
   } else {
     progress_bar_init(
       total = lst_size,
@@ -95,7 +94,7 @@ rd_translate <- function(rd_content, lang, context_size) {
     if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
       progress_bar_update_text("Value")
       lst$value$outro <- rd_field_translate(v$outro, lang, rs, context_summary)
-      progress_bar_update_done(lst$value)
+      progress_bar_update_done(v$outro)
     }
   }
 

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -11,192 +11,135 @@ rd_translate <- function(rd_content, lang) {
   if (length(args) > 0) {
     use_args <- c(use_args, args)
   }
-  use_lang <- rs$run(
+  rs$run(
     function(x) rlang::exec(mall::llm_use, !!!x),
     args = list(x = use_args)
   )
-  standard_tags <- c(
-    "\\title",
-    "\\description",
-    "\\arguments",
-    "\\value",
-    "\\details",
-    "\\seealso",
-    "\\note",
-    "\\author"
-  )
-  non_standard_tags <- c("\\section", "\\examples")
-  all_tags <- rd_content |>
-    map_chr(\(x) attr(x, "Rd_tag"))
-  filter_obj <- standard_tags |>
-    c(non_standard_tags) |>
-    map(\(x) rd_content[all_tags == x])
-  section_no <- 0
-  obj_total <- filter_obj |>
-    object.size() |>
-    as.integer()
+
+  lst <- rd_to_list(rd_content)
+  nms <- names(lst)
+
+  tag_label <- ""
   progress_bar_init(
-    total = obj_total,
-    format = "[{section_no}/{length(filter_obj)}] {pb_bar} {pb_percent} | {tag_label}"
+    total = rd_count_fields(lst),
+    format = "[{pb_current}/{pb_total}] {pb_bar} {pb_percent} | {tag_label}"
   )
-  obj_progress <- 0
-  for (i in seq_along(rd_content)) {
-    rd_i <- rd_content[[i]]
-    tag_name <- attr(rd_i, "Rd_tag")
-    if (tag_name %in% c(standard_tags, non_standard_tags)) {
-      section_no <- section_no + 1
-      tag_label <- NULL
-      tag_label <- tag_name
-      if (tag_name %in% standard_tags) {
-        progress_bar_update(tag_to_label(tag_name))
-        if (any(map(rd_i, attr, "Rd_tag") == "\\item")) {
-          for (k in seq_along(rd_i)) {
-            rd_k <- rd_i[[k]]
-            if (length(rd_k) > 1) {
-              tag_label <- glue(
-                "{tag_to_label(tag_name)} - '{as.character(rd_k[[1]])}'"
-              )
-              rd_content[[i]][[k]][[2]] <- rd_prep_translate(
-                rd_k[[2]],
-                lang,
-                rs
-              )
-            } else {
-              item_translation <- suppressWarnings(
-                try(rd_prep_translate(rd_k, lang, rs), silent = TRUE)
-              )
-              if (!inherits(item_translation, "try-error")) {
-                rd_content[[i]][[k]] <- item_translation
-              }
-            }
-            progress_bar_update(obj = rd_k)
-          }
-        } else {
-          rd_content[[i]] <- rd_prep_translate(rd_i, lang, rs)
-          progress_bar_update(obj = rd_i)
-        }
-      }
-      if (tag_name == "\\section") {
-        tag_full <- rd_extract_text(rd_i[[1]], rs)
-        if (nchar(tag_full > 17)) {
-          tag_full <- paste0(substr(tag_full, 1, 17), "...")
-        }
-        progress_bar_update(glue("Section: '{tag_full}'"))
-        rd_content[[i]][[1]] <- rd_prep_translate(rd_i[[1]], lang, rs)
-        progress_bar_update(obj = rd_i[[1]])
-        rd_content[[i]][[2]] <- rd_prep_translate(rd_i[[2]], lang, rs)
-        progress_bar_update(obj = rd_i[[2]])
-      }
-      if (tag_name == "\\examples") {
-        progress_bar_update("Examples")
-        for (k in seq_along(rd_i)) {
-          rd_k <- rd_i[[k]]
-          k_attrs <- attributes(rd_k)
-          rd_char <- as.character(rd_k)
-          if (inherits(rd_k, "list")) {
-            rd_k <- map(rd_char, rd_comment_translate, lang, rs)
-          }
-          if (inherits(rd_k, "character")) {
-            rd_k <- rd_comment_translate(rd_char, lang, rs)
-          }
-          attributes(rd_k) <- k_attrs
-          rd_i[[k]] <- rd_k
-          progress_bar_update(obj = rd_k)
-        }
-        rd_content[[i]] <- rd_i
-      }
-    }
-    if (tag_name == "\\name") {
-      topic_name <- rd_i
+
+  # Prose scalar / vector fields
+  for (field in c(
+    "title",
+    "description",
+    "details",
+    "note",
+    "author",
+    "references",
+    "seealso"
+  )) {
+    if (!is.null(lst[[field]])) {
+      progress_bar_update(tag_to_label(field))
+      lst[[field]] <- rd_field_translate(lst[[field]], lang, rs)
     }
   }
+
+  # Arguments
+  for (i in seq_along(lst$arguments)) {
+    arg_name <- lst$arguments[[i]]$argument
+    progress_bar_update(glue("Argument: '{arg_name}'"))
+    lst$arguments[[i]]$description <- rd_field_translate(
+      lst$arguments[[i]]$description,
+      lang,
+      rs
+    )
+  }
+
+  # Value
+  if (!is.null(lst$value)) {
+    v <- lst$value
+    if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
+      progress_bar_update("Value")
+      lst$value$intro <- rd_field_translate(v$intro, lang, rs)
+    }
+    for (i in seq_along(v$components)) {
+      comp_name <- v$components[[i]]$component
+      progress_bar_update(glue("Value: '{comp_name}'"))
+      lst$value$components[[i]]$description <- rd_field_translate(
+        v$components[[i]]$description,
+        lang,
+        rs
+      )
+    }
+    if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
+      progress_bar_update("Value")
+      lst$value$outro <- rd_field_translate(v$outro, lang, rs)
+    }
+  }
+
+  # Named sections
+  sec_idx <- which(nms == "section")
+  for (i in seq_along(sec_idx)) {
+    s <- lst[[sec_idx[[i]]]]
+    tag_full <- s$title
+    if (nchar(tag_full) > 17) {
+      tag_full <- paste0(substr(tag_full, 1, 17), "...")
+    }
+    progress_bar_update(glue("Section: '{tag_full}'"))
+    lst[[sec_idx[[i]]]]$title <- rd_field_translate(s$title, lang, rs)
+    progress_bar_update(glue("Section: '{tag_full}'"))
+    lst[[sec_idx[[i]]]]$contents <- rd_field_translate(s$contents, lang, rs)
+  }
+
   cli_progress_done()
   cli_alert_success("{.pkg lang} - {.emph Translation complete}")
-  tag_name <- NULL
-  rs$close()
-  rd_text <- paste0(as.character(rd_content), collapse = "")
-  topic_path <- path(tempdir(), topic_name, ext = "Rd")
-  writeLines(rd_text, topic_path)
-  topic_path
+
+  rd_str <- list_to_rd(lst)
+  tmp <- tempfile(fileext = ".Rd")
+  writeLines(rd_str, tmp)
+  tmp
 }
 
-rd_comment_translate <- function(x, lang, rs) {
-  rd_char <- as.character(x)
-  if (length(rd_char) == 1) {
-    if (substr(rd_char, 1, 2) == "# ") {
-      last_char <- substr(rd_char, nchar(rd_char), nchar(rd_char))
-      n_char <- ifelse(last_char == "\n", 1, 0)
-      rd_char <- substr(rd_char, 3, nchar(rd_char) - n_char)
-      rd_char <- rs$run(
-        function(x, language) {
-          mall::llm_vec_translate(x = x, language = language)
-        },
-        args = list(x = rd_char, language = lang)
-      )
-      rd_char <- paste0("# ", rd_char, "\n")
-    } else {}
-    rd_char <- gsub("%", "\\\\%", rd_char)
-    attributes(rd_char) <- attributes(x)
-    x <- rd_char
-  }
-  x
-}
-
-rd_prep_translate <- function(x, lang, rs) {
-  txt <- rd_extract_text(x, rs)
-  rd_text <- gsub("\U2018", "'", txt)
-  rd_text <- gsub("\U2019", "'", rd_text)
+rd_field_translate <- function(x, lang, rs) {
   add_prompt <- paste(
     "Do not translate anything between single quotes.",
     "Do not translate the words: NULL, TRUE, FALSE, NA, Nan.",
     "Do not expand on the subject, simply translate the original text"
   )
-  tag_text <- rs$run(
+  rs$run(
     function(x, y, z) {
       mall::llm_vec_translate(x = x, language = y, additional_prompt = z)
     },
-    args = list(x = rd_text, y = lang, z = add_prompt)
+    args = list(x = paste(x, collapse = "\n"), y = lang, z = add_prompt)
   )
-  funcs <- txt |>
-    strsplit("\U2018") |>
-    unlist() |>
-    map(strsplit, "\U2019") |>
-    map(unlist) |>
-    keep(\(x) length(x) == 2) |>
-    map(head, 1)
-  for (func in funcs) {
-    func <- sub("\\(", "\\\\(", func)
-    func <- sub("\\)", "\\\\)", func)
-    tag_text <- sub(
-      paste0("'", func, "'"),
-      paste0("\\\\code{", func, "}"),
-      tag_text
-    )
-  }
-  obj <- list(tag_text)
-  attrs <- attributes(x[[1]])
-  if (!is.null(attrs)) {
-    attr(attrs, "Rd_tag") <- "TEXT"
-    attributes(tag_text) <- attrs
-  }
-  attributes(obj) <- attributes(x)
-  obj
 }
 
-rd_extract_text <- function(x, rs) {
-  txt <- rs$run(
-    function(x) {
-      tools::Rd2txt_options(
-        width = Inf,
-        underline_titles = TRUE,
-        code_quote = TRUE
-      )
-      capture.output(tools::Rd2txt(x, fragment = TRUE))
-    },
-    args = list(x = x)
-  )
-  txt <- gsub("_\b", "", txt)
-  paste0(txt, collapse = "\n\n")
+rd_count_fields <- function(lst) {
+  nms <- names(lst)
+  n <- 0L
+  for (field in c(
+    "title",
+    "description",
+    "details",
+    "note",
+    "author",
+    "references",
+    "seealso"
+  )) {
+    if (!is.null(lst[[field]])) {
+      n <- n + 1L
+    }
+  }
+  n <- n + length(lst$arguments)
+  if (!is.null(lst$value)) {
+    v <- lst$value
+    if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
+      n <- n + 1L
+    }
+    n <- n + length(v$components)
+    if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
+      n <- n + 1L
+    }
+  }
+  n <- n + length(which(nms == "section")) * 2L
+  n
 }
 
 to_title <- function(x) {
@@ -221,6 +164,7 @@ tag_to_label <- function(x) {
     "description" = "Description",
     "value" = "Value",
     "details" = "Details",
+    "note" = "Note",
     "seealso" = "See Also",
     "examples" = "Examples",
     "arguments" = "Arguments",
@@ -228,7 +172,8 @@ tag_to_label <- function(x) {
     "output" = "Output",
     "returns" = "Returns",
     "return" = "Return",
-    "seealso" = "See Also"
+    "author" = "Author",
+    "references" = "References"
   )
   match <- tag_labels[names(tag_labels) == x]
   if (length(match) > 0) {

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -16,8 +16,14 @@ rd_translate <- function(rd_content, lang) {
     args = list(x = use_args)
   )
   standard_tags <- c(
-    "\\title", "\\description", "\\arguments", "\\value",
-    "\\details", "\\seealso", "\\note", "\\author"
+    "\\title",
+    "\\description",
+    "\\arguments",
+    "\\value",
+    "\\details",
+    "\\seealso",
+    "\\note",
+    "\\author"
   )
   non_standard_tags <- c("\\section", "\\examples")
   all_tags <- rd_content |>
@@ -47,8 +53,14 @@ rd_translate <- function(rd_content, lang) {
           for (k in seq_along(rd_i)) {
             rd_k <- rd_i[[k]]
             if (length(rd_k) > 1) {
-              tag_label <- glue("{tag_to_label(tag_name)} - '{as.character(rd_k[[1]])}'")
-              rd_content[[i]][[k]][[2]] <- rd_prep_translate(rd_k[[2]], lang, rs)
+              tag_label <- glue(
+                "{tag_to_label(tag_name)} - '{as.character(rd_k[[1]])}'"
+              )
+              rd_content[[i]][[k]][[2]] <- rd_prep_translate(
+                rd_k[[2]],
+                lang,
+                rs
+              )
             } else {
               item_translation <- suppressWarnings(
                 try(rd_prep_translate(rd_k, lang, rs), silent = TRUE)
@@ -116,7 +128,9 @@ rd_comment_translate <- function(x, lang, rs) {
       n_char <- ifelse(last_char == "\n", 1, 0)
       rd_char <- substr(rd_char, 3, nchar(rd_char) - n_char)
       rd_char <- rs$run(
-        function(x, language) mall::llm_vec_translate(x = x, language = language),
+        function(x, language) {
+          mall::llm_vec_translate(x = x, language = language)
+        },
         args = list(x = rd_char, language = lang)
       )
       rd_char <- paste0("# ", rd_char, "\n")
@@ -153,7 +167,11 @@ rd_prep_translate <- function(x, lang, rs) {
   for (func in funcs) {
     func <- sub("\\(", "\\\\(", func)
     func <- sub("\\)", "\\\\)", func)
-    tag_text <- sub(paste0("'", func, "'"), paste0("\\\\code{", func, "}"), tag_text)
+    tag_text <- sub(
+      paste0("'", func, "'"),
+      paste0("\\\\code{", func, "}"),
+      tag_text
+    )
   }
   obj <- list(tag_text)
   attrs <- attributes(x[[1]])
@@ -230,7 +248,11 @@ progress_bar_init <- function(total, format, envir = parent.frame()) {
   }
 }
 
-progress_bar_update <- function(txt = NULL, obj = NULL, envir = parent.frame()) {
+progress_bar_update <- function(
+  txt = NULL,
+  obj = NULL,
+  envir = parent.frame()
+) {
   if (is_interactive()) {
     if (is.null(obj)) {
       set <- NULL

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -23,7 +23,7 @@ rd_translate <- function(rd_content, lang) {
   n_fields <- rd_count_fields(lst)
   tag_label <- ""
   progress_bar_init(
-    total = as.integer(object.size(lst)),
+    total = rd_trans_size(lst),
     format = "[{section_no}/{n_fields}] {pb_bar} {pb_percent} | {tag_label}"
   )
 
@@ -38,24 +38,24 @@ rd_translate <- function(rd_content, lang) {
     "seealso"
   )) {
     if (!is.null(lst[[field]])) {
+      lst[[field]] <- rd_field_translate(lst[[field]], lang, rs)
       section_no <- section_no + 1L
       progress_bar_update(tag_to_label(field), obj = lst[[field]])
-      lst[[field]] <- rd_field_translate(lst[[field]], lang, rs)
     }
   }
 
   # Arguments
   for (i in seq_along(lst$arguments)) {
     arg_name <- lst$arguments[[i]]$argument
-    section_no <- section_no + 1L
-    progress_bar_update(
-      glue("Argument: '{arg_name}'"),
-      obj = lst$arguments[[i]]$description
-    )
     lst$arguments[[i]]$description <- rd_field_translate(
       lst$arguments[[i]]$description,
       lang,
       rs
+    )
+    section_no <- section_no + 1L
+    progress_bar_update(
+      glue("Argument: '{arg_name}'"),
+      obj = lst$arguments[[i]]
     )
   }
 
@@ -63,27 +63,27 @@ rd_translate <- function(rd_content, lang) {
   if (!is.null(lst$value)) {
     v <- lst$value
     if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
-      section_no <- section_no + 1L
-      progress_bar_update("Value", obj = v$intro)
       lst$value$intro <- rd_field_translate(v$intro, lang, rs)
+      section_no <- section_no + 1L
+      progress_bar_update("Value", obj = lst$value$intro)
     }
     for (i in seq_along(v$components)) {
       comp_name <- v$components[[i]]$component
-      section_no <- section_no + 1L
-      progress_bar_update(
-        glue("Value: '{comp_name}'"),
-        obj = v$components[[i]]$description
-      )
       lst$value$components[[i]]$description <- rd_field_translate(
         v$components[[i]]$description,
         lang,
         rs
       )
+      section_no <- section_no + 1L
+      progress_bar_update(
+        glue("Value: '{comp_name}'"),
+        obj = lst$value$components[[i]]
+      )
     }
     if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
-      section_no <- section_no + 1L
-      progress_bar_update("Value", obj = v$outro)
       lst$value$outro <- rd_field_translate(v$outro, lang, rs)
+      section_no <- section_no + 1L
+      progress_bar_update("Value", obj = lst$value$outro)
     }
   }
 
@@ -95,18 +95,22 @@ rd_translate <- function(rd_content, lang) {
     if (nchar(tag_full) > 17) {
       tag_full <- paste0(substr(tag_full, 1, 17), "...")
     }
-    section_no <- section_no + 1L
-    progress_bar_update(glue("Section: '{tag_full}'"), obj = s$title)
     lst[[sec_idx[[i]]]]$title <- rd_field_translate(s$title, lang, rs)
     section_no <- section_no + 1L
-    progress_bar_update(glue("Section: '{tag_full}'"), obj = s$contents)
+    progress_bar_update(
+      glue("Section: '{tag_full}'"),
+      obj = lst[[sec_idx[[i]]]]$title
+    )
     lst[[sec_idx[[i]]]]$contents <- rd_field_translate(s$contents, lang, rs)
+    section_no <- section_no + 1L
+    progress_bar_update(
+      glue("Section: '{tag_full}'"),
+      obj = lst[[sec_idx[[i]]]]$contents
+    )
   }
 
   # Examples — translate # comments only
   if (!is.null(lst$examples)) {
-    section_no <- section_no + 1L
-    progress_bar_update("Examples", obj = lst$examples)
     ex <- lst$examples
     if (!is.null(ex$code_run)) {
       lst$examples$code_run <- rd_examples_translate(ex$code_run, lang, rs)
@@ -118,6 +122,8 @@ rd_translate <- function(rd_content, lang) {
         rs
       )
     }
+    section_no <- section_no + 1L
+    progress_bar_update("Examples")
   }
 
   cli_progress_done()
@@ -158,6 +164,46 @@ rd_examples_translate <- function(code, lang, rs) {
   )
   lines[comment_idx] <- paste0("# ", translated)
   paste(lines, collapse = "\n")
+}
+
+rd_trans_size <- function(lst) {
+  nms <- names(lst)
+  size <- 0L
+  for (field in c(
+    "title",
+    "description",
+    "details",
+    "note",
+    "author",
+    "references",
+    "seealso"
+  )) {
+    if (!is.null(lst[[field]])) {
+      size <- size + as.integer(object.size(lst[[field]]))
+    }
+  }
+  for (i in seq_along(lst$arguments)) {
+    size <- size + as.integer(object.size(lst$arguments[[i]]))
+  }
+  if (!is.null(lst$value)) {
+    v <- lst$value
+    if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
+      size <- size + as.integer(object.size(v$intro))
+    }
+    for (i in seq_along(v$components)) {
+      size <- size + as.integer(object.size(v$components[[i]]))
+    }
+    if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
+      size <- size + as.integer(object.size(v$outro))
+    }
+  }
+  sec_idx <- which(nms == "section")
+  for (i in seq_along(sec_idx)) {
+    s <- lst[[sec_idx[[i]]]]
+    size <- size + as.integer(object.size(s$title))
+    size <- size + as.integer(object.size(s$contents))
+  }
+  size
 }
 
 rd_count_fields <- function(lst) {
@@ -241,7 +287,12 @@ progress_bar_init <- function(total, format, envir = parent.frame()) {
   if (is_interactive()) {
     .lang_env$size <- total
     .lang_env$progress <- 0
-    cli_progress_bar(total = total, format = format, .envir = envir)
+    cli_progress_bar(
+      total = total,
+      format = format,
+      auto_terminate = FALSE,
+      .envir = envir
+    )
   }
 }
 

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -1,51 +1,3 @@
-lang_rs_refresh <- function(rs) {
-  lang_args <- lang_use_impl(.is_internal = TRUE)
-  backend <- lang_args[["backend"]]
-  use_args <- list(.cache = lang_args[[".cache"]])
-  if (!is.null(backend)) {
-    use_args[["backend"]] <- backend
-  }
-  # Chat objects have their model built in; passing model separately is an error
-  if (!inherits(backend, "Chat")) {
-    use_args[["model"]] <- lang_args[["model"]]
-  }
-  args <- lang_args[["args"]]
-  if (length(args) > 0) {
-    use_args <- c(use_args, args)
-  }
-  rs$run(
-    function(x) rlang::exec(mall::llm_use, !!!x),
-    args = list(x = use_args)
-  )
-}
-
-lang_rs_hash <- function() {
-  s <- .lang_env$session
-  paste(s[["backend"]], s[["model"]], s[[".cache"]], collapse = "|")
-}
-
-lang_rs_get <- function() {
-  rs <- .lang_env$rs
-  if (!is.null(rs) && rs$is_alive()) {
-    if (rs$get_state() == "starting") {
-      rs$poll_process(5000L)
-    }
-    if (rs$get_state() == "idle") {
-      current_hash <- lang_rs_hash()
-      if (!identical(.lang_env$rs_hash, current_hash)) {
-        lang_rs_refresh(rs)
-        .lang_env$rs_hash <- current_hash
-      }
-      return(rs)
-    }
-  }
-  rs <- callr::r_session$new()
-  .lang_env$rs <- rs
-  lang_rs_refresh(rs)
-  .lang_env$rs_hash <- lang_rs_hash()
-  rs
-}
-
 rd_translate <- function(rd_content, lang, context_size) {
   lst <- rd_to_list(rd_content)
   nms <- names(lst)
@@ -54,10 +6,14 @@ rd_translate <- function(rd_content, lang, context_size) {
 
   rs <- lang_rs_get()
 
+  lst_size <- as.integer(object.size(lst[
+    !names(lst) %in% c("examples", "usage")
+  ]))
+
   if (context_size >= 1L) {
     full_doc_text <- rd_flatten(lst)
     progress_bar_init(
-      total = rd_trans_size(lst) +
+      total = lst_size +
         as.integer(object.size(full_doc_text)) +
         context_size * 8L,
       format = "{pb_bar} {pb_percent} | {tag_label}"
@@ -77,7 +33,7 @@ rd_translate <- function(rd_content, lang, context_size) {
     progress_bar_update_text("Translating...")
   } else {
     progress_bar_init(
-      total = rd_trans_size(lst),
+      total = lst_size,
       format = "{pb_bar} {pb_percent} | {tag_label}"
     )
     context_summary <- NULL
@@ -115,7 +71,7 @@ rd_translate <- function(rd_content, lang, context_size) {
       rs,
       context_summary
     )
-    progress_bar_update_done(lst$arguments[[i]]$description)
+    progress_bar_update_done(lst$arguments[[i]])
   }
 
   # Value
@@ -124,7 +80,6 @@ rd_translate <- function(rd_content, lang, context_size) {
     if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
       progress_bar_update_text("Value")
       lst$value$intro <- rd_field_translate(v$intro, lang, rs, context_summary)
-      progress_bar_update_done(lst$value$intro)
     }
     for (i in seq_along(v$components)) {
       comp_name <- v$components[[i]]$component
@@ -135,12 +90,12 @@ rd_translate <- function(rd_content, lang, context_size) {
         rs,
         context_summary
       )
-      progress_bar_update_done(lst$value$components[[i]]$description)
+      progress_bar_update_done(lst$value$components[[i]])
     }
     if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
       progress_bar_update_text("Value")
       lst$value$outro <- rd_field_translate(v$outro, lang, rs, context_summary)
-      progress_bar_update_done(lst$value$outro)
+      progress_bar_update_done(lst$value)
     }
   }
 
@@ -160,7 +115,7 @@ rd_translate <- function(rd_content, lang, context_size) {
       rs,
       context_summary
     )
-    progress_bar_update_done(lst[[sec_idx[[i]]]]$title)
+    progress_bar_update_done(lst[[sec_idx[[i]]]])
     progress_bar_update_text(lbl)
     lst[[sec_idx[[i]]]]$contents <- rd_field_translate(
       s$contents,
@@ -168,7 +123,7 @@ rd_translate <- function(rd_content, lang, context_size) {
       rs,
       context_summary
     )
-    progress_bar_update_done(lst[[sec_idx[[i]]]]$contents)
+    progress_bar_update_done(lst[[sec_idx[[i]]]])
   }
 
   # Examples — translate # comments only
@@ -257,49 +212,6 @@ rd_examples_translate <- function(code, lang, rs, context_summary = NULL) {
 }
 
 
-rd_trans_size <- function(lst) {
-  nms <- names(lst)
-  size <- 0L
-  for (field in c(
-    "title",
-    "description",
-    "details",
-    "note",
-    "author",
-    "references",
-    "seealso"
-  )) {
-    if (!is.null(lst[[field]])) {
-      size <- size + as.integer(object.size(lst[[field]]))
-    }
-  }
-  for (i in seq_along(lst$arguments)) {
-    size <- size + as.integer(object.size(lst$arguments[[i]]$description))
-  }
-  if (!is.null(lst$value)) {
-    v <- lst$value
-    if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
-      size <- size + as.integer(object.size(v$intro))
-    }
-    for (i in seq_along(v$components)) {
-      size <- size + as.integer(object.size(v$components[[i]]$description))
-    }
-    if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
-      size <- size + as.integer(object.size(v$outro))
-    }
-  }
-  sec_idx <- which(nms == "section")
-  for (i in seq_along(sec_idx)) {
-    s <- lst[[sec_idx[[i]]]]
-    size <- size + as.integer(object.size(s$title))
-    size <- size + as.integer(object.size(s$contents))
-  }
-  if (!is.null(lst$examples)) {
-    size <- size + as.integer(object.size(lst$examples))
-  }
-  size
-}
-
 rd_count_fields <- function(lst) {
   nms <- names(lst)
   n <- 0L
@@ -332,6 +244,54 @@ rd_count_fields <- function(lst) {
     n <- n + 1L
   }
   n
+}
+
+lang_rs_refresh <- function(rs) {
+  lang_args <- lang_use_impl(.is_internal = TRUE)
+  backend <- lang_args[["backend"]]
+  use_args <- list(.cache = lang_args[[".cache"]])
+  if (!is.null(backend)) {
+    use_args[["backend"]] <- backend
+  }
+  # Chat objects have their model built in; passing model separately is an error
+  if (!inherits(backend, "Chat")) {
+    use_args[["model"]] <- lang_args[["model"]]
+  }
+  args <- lang_args[["args"]]
+  if (length(args) > 0) {
+    use_args <- c(use_args, args)
+  }
+  rs$run(
+    function(x) rlang::exec(mall::llm_use, !!!x),
+    args = list(x = use_args)
+  )
+}
+
+lang_rs_hash <- function() {
+  s <- .lang_env$session
+  paste(s[["backend"]], s[["model"]], s[[".cache"]], collapse = "|")
+}
+
+lang_rs_get <- function() {
+  rs <- .lang_env$rs
+  if (!is.null(rs) && rs$is_alive()) {
+    if (rs$get_state() == "starting") {
+      rs$poll_process(5000L)
+    }
+    if (rs$get_state() == "idle") {
+      current_hash <- lang_rs_hash()
+      if (!identical(.lang_env$rs_hash, current_hash)) {
+        lang_rs_refresh(rs)
+        .lang_env$rs_hash <- current_hash
+      }
+      return(rs)
+    }
+  }
+  rs <- callr::r_session$new()
+  .lang_env$rs <- rs
+  lang_rs_refresh(rs)
+  .lang_env$rs_hash <- lang_rs_hash()
+  rs
 }
 
 to_title <- function(x) {

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -47,18 +47,16 @@ lang_rs_get <- function() {
 }
 
 rd_translate <- function(rd_content, lang, context_size) {
-  rs <- lang_rs_get()
-
   lst <- rd_to_list(rd_content)
   nms <- names(lst)
 
-  section_no <- 0L
-  n_fields <- rd_count_fields(lst, context_size)
-  tag_label <- ""
+  tag_label <- "Initializing..."
   progress_bar_init(
-    total = rd_trans_size(lst),
-    format = "[{section_no}/{n_fields}] {pb_bar} {pb_percent} | {tag_label}"
+    total = rd_trans_size(lst, context_size),
+    format = "{pb_bar} {pb_percent} | {tag_label}"
   )
+
+  rs <- lang_rs_get()
 
   if (context_size >= 1L) {
     full_doc_text <- rd_flatten(lst)
@@ -67,37 +65,19 @@ rd_translate <- function(rd_content, lang, context_size) {
       function(text, n) mall::llm_vec_summarize(text, max_words = n),
       args = list(text = full_doc_text, n = context_size)
     )
-    section_no <- section_no + 1L
+    progress_bar_update("Context: Summarizing", obj = summary_en)
     progress_bar_update("Context: Translating summary")
     context_summary <- rs$run(
       function(x, lang) mall::llm_vec_translate(x, language = lang),
       args = list(x = summary_en, lang = lang)
     )
-    section_no <- section_no + 1L
+    progress_bar_update("Context: Translating summary", obj = context_summary)
   } else {
     context_summary <- NULL
   }
 
-  # Build shared prompt once (all fields use the same context block)
-  context_block <- if (!is.null(context_summary)) {
-    paste0(
-      "For context, here is a short summary of the full help page in the target language:\n\n",
-      context_summary,
-      "\n\n"
-    )
-  } else {
-    ""
-  }
-  add_prompt <- paste(
-    context_block,
-    "Do not translate anything between single quotes.",
-    "Do not translate the words: NULL, TRUE, FALSE, NA, Nan.",
-    "Do not expand on the subject, simply translate the original text"
-  )
-
-  # --- Collect all translatable texts into one vector ---
-
-  prose_fields <- c(
+  # Prose fields
+  for (field in c(
     "title",
     "description",
     "details",
@@ -105,172 +85,110 @@ rd_translate <- function(rd_content, lang, context_size) {
     "author",
     "references",
     "seealso"
-  )
-  prose_present <- prose_fields[
-    !vapply(lst[prose_fields], is.null, logical(1L))
-  ]
-  texts <- vapply(
-    prose_present,
-    function(f) paste(lst[[f]], collapse = "\n"),
-    character(1L)
-  )
-
-  arg_start <- length(texts) + 1L
-  texts <- c(
-    texts,
-    vapply(
-      lst$arguments,
-      function(a) paste(a$description, collapse = "\n"),
-      character(1L)
-    )
-  )
-
-  value_intro_pos <- NULL
-  value_comp_start <- NULL
-  value_outro_pos <- NULL
-  if (!is.null(lst$value)) {
-    v <- lst$value
-    if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
-      value_intro_pos <- length(texts) + 1L
-      texts <- c(texts, paste(v$intro, collapse = "\n"))
-    }
-    if (length(v$components) > 0L) {
-      value_comp_start <- length(texts) + 1L
-      texts <- c(
-        texts,
-        vapply(
-          v$components,
-          function(c) paste(c$description, collapse = "\n"),
-          character(1L)
-        )
+  )) {
+    if (!is.null(lst[[field]])) {
+      progress_bar_update(tag_to_label(field))
+      lst[[field]] <- rd_field_translate(
+        lst[[field]],
+        lang,
+        rs,
+        context_summary
       )
-    }
-    if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
-      value_outro_pos <- length(texts) + 1L
-      texts <- c(texts, paste(v$outro, collapse = "\n"))
+      progress_bar_update(tag_to_label(field), obj = lst[[field]])
     }
   }
 
+  # Arguments
+  for (i in seq_along(lst$arguments)) {
+    arg_name <- lst$arguments[[i]]$argument
+    progress_bar_update(glue("Argument: '{arg_name}'"))
+    lst$arguments[[i]]$description <- rd_field_translate(
+      lst$arguments[[i]]$description,
+      lang,
+      rs,
+      context_summary
+    )
+    progress_bar_update(
+      glue("Argument: '{arg_name}'"),
+      obj = lst$arguments[[i]]$description
+    )
+  }
+
+  # Value
+  if (!is.null(lst$value)) {
+    v <- lst$value
+    if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
+      progress_bar_update("Value")
+      lst$value$intro <- rd_field_translate(v$intro, lang, rs, context_summary)
+      progress_bar_update("Value", obj = lst$value$intro)
+    }
+    for (i in seq_along(v$components)) {
+      comp_name <- v$components[[i]]$component
+      progress_bar_update(glue("Value: '{comp_name}'"))
+      lst$value$components[[i]]$description <- rd_field_translate(
+        v$components[[i]]$description,
+        lang,
+        rs,
+        context_summary
+      )
+      progress_bar_update(
+        glue("Value: '{comp_name}'"),
+        obj = lst$value$components[[i]]$description
+      )
+    }
+    if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
+      progress_bar_update("Value")
+      lst$value$outro <- rd_field_translate(v$outro, lang, rs, context_summary)
+      progress_bar_update("Value", obj = lst$value$outro)
+    }
+  }
+
+  # Named sections
   sec_idx <- which(nms == "section")
-  sec_labels <- character(length(sec_idx))
-  sec_title_pos <- integer(length(sec_idx))
-  sec_content_pos <- integer(length(sec_idx))
   for (i in seq_along(sec_idx)) {
     s <- lst[[sec_idx[[i]]]]
     tag_full <- s$title
     if (nchar(tag_full) > 17L) {
       tag_full <- paste0(substr(tag_full, 1L, 17L), "...")
     }
-    sec_labels[[i]] <- tag_full
-    sec_title_pos[[i]] <- length(texts) + 1L
-    texts <- c(texts, paste(s$title, collapse = "\n"))
-    sec_content_pos[[i]] <- length(texts) + 1L
-    texts <- c(texts, paste(s$contents, collapse = "\n"))
-  }
-
-  ex_info <- list()
-  if (!is.null(lst$examples)) {
-    for (code_field in c("code_run", "code_dont_run")) {
-      if (!is.null(lst$examples[[code_field]])) {
-        lines <- strsplit(lst$examples[[code_field]], "\n", fixed = TRUE)[[1L]]
-        cidx <- which(substr(lines, 1L, 2L) == "# ")
-        if (length(cidx) > 0L) {
-          ex_info[[code_field]] <- list(
-            lines = lines,
-            cidx = cidx,
-            start = length(texts) + 1L,
-            n = length(cidx)
-          )
-          texts <- c(texts, substr(lines[cidx], 3L, nchar(lines[cidx])))
-        }
-      }
-    }
-  }
-
-  # --- One batch IPC call for all fields ---
-  if (length(texts) > 0L) {
-    translated <- rs$run(
-      function(x, lang, prompt) {
-        mall::llm_vec_translate(
-          x = x,
-          language = lang,
-          additional_prompt = prompt
-        )
-      },
-      args = list(x = texts, lang = lang, prompt = add_prompt)
+    lbl <- glue("Section: '{tag_full}'")
+    progress_bar_update(lbl)
+    lst[[sec_idx[[i]]]]$title <- rd_field_translate(
+      s$title,
+      lang,
+      rs,
+      context_summary
     )
-
-    # Distribute results back and update progress bar per field
-
-    for (k in seq_along(prose_present)) {
-      f <- prose_present[[k]]
-      lst[[f]] <- translated[[k]]
-      section_no <- section_no + 1L
-      progress_bar_update(tag_to_label(f), obj = lst[[f]])
-    }
-
-    for (i in seq_along(lst$arguments)) {
-      lst$arguments[[i]]$description <- translated[[arg_start + i - 1L]]
-      section_no <- section_no + 1L
-      progress_bar_update(
-        glue("Argument: '{lst$arguments[[i]]$argument}'"),
-        obj = lst$arguments[[i]]
-      )
-    }
-
-    if (!is.null(lst$value)) {
-      if (!is.null(value_intro_pos)) {
-        lst$value$intro <- translated[[value_intro_pos]]
-        section_no <- section_no + 1L
-        progress_bar_update("Value", obj = lst$value$intro)
-      }
-      if (!is.null(value_comp_start)) {
-        for (i in seq_along(lst$value$components)) {
-          comp_name <- lst$value$components[[i]]$component
-          lst$value$components[[i]]$description <- translated[[
-            value_comp_start + i - 1L
-          ]]
-          section_no <- section_no + 1L
-          progress_bar_update(
-            glue("Value: '{comp_name}'"),
-            obj = lst$value$components[[i]]
-          )
-        }
-      }
-      if (!is.null(value_outro_pos)) {
-        lst$value$outro <- translated[[value_outro_pos]]
-        section_no <- section_no + 1L
-        progress_bar_update("Value", obj = lst$value$outro)
-      }
-    }
-
-    for (i in seq_along(sec_idx)) {
-      lst[[sec_idx[[i]]]]$title <- translated[[sec_title_pos[[i]]]]
-      section_no <- section_no + 1L
-      progress_bar_update(
-        glue("Section: '{sec_labels[[i]]}'"),
-        obj = lst[[sec_idx[[i]]]]$title
-      )
-      lst[[sec_idx[[i]]]]$contents <- translated[[sec_content_pos[[i]]]]
-      section_no <- section_no + 1L
-      progress_bar_update(
-        glue("Section: '{sec_labels[[i]]}'"),
-        obj = lst[[sec_idx[[i]]]]$contents
-      )
-    }
-
-    for (code_field in names(ex_info)) {
-      info <- ex_info[[code_field]]
-      info$lines[info$cidx] <- paste0(
-        "# ",
-        translated[info$start:(info$start + info$n - 1L)]
-      )
-      lst$examples[[code_field]] <- paste(info$lines, collapse = "\n")
-    }
+    progress_bar_update(lbl, obj = lst[[sec_idx[[i]]]]$title)
+    progress_bar_update(lbl)
+    lst[[sec_idx[[i]]]]$contents <- rd_field_translate(
+      s$contents,
+      lang,
+      rs,
+      context_summary
+    )
+    progress_bar_update(lbl, obj = lst[[sec_idx[[i]]]]$contents)
   }
 
+  # Examples — translate # comments only
   if (!is.null(lst$examples)) {
-    section_no <- section_no + 1L
+    progress_bar_update("Examples")
+    if (!is.null(lst$examples$code_run)) {
+      lst$examples$code_run <- rd_examples_translate(
+        lst$examples$code_run,
+        lang,
+        rs,
+        context_summary
+      )
+    }
+    if (!is.null(lst$examples$code_dont_run)) {
+      lst$examples$code_dont_run <- rd_examples_translate(
+        lst$examples$code_dont_run,
+        lang,
+        rs,
+        context_summary
+      )
+    }
     progress_bar_update("Examples", obj = lst$examples)
   }
 
@@ -337,10 +255,10 @@ rd_examples_translate <- function(code, lang, rs, context_summary = NULL) {
   paste(lines, collapse = "\n")
 }
 
-rd_trans_size <- function(lst) {
+rd_trans_size <- function(lst, context_size = 0L) {
   nms <- names(lst)
   size <- 0L
-  for (field in c(
+  prose_fields <- c(
     "title",
     "description",
     "details",
@@ -348,13 +266,14 @@ rd_trans_size <- function(lst) {
     "author",
     "references",
     "seealso"
-  )) {
+  )
+  for (field in prose_fields) {
     if (!is.null(lst[[field]])) {
       size <- size + as.integer(object.size(lst[[field]]))
     }
   }
   for (i in seq_along(lst$arguments)) {
-    size <- size + as.integer(object.size(lst$arguments[[i]]))
+    size <- size + as.integer(object.size(lst$arguments[[i]]$description))
   }
   if (!is.null(lst$value)) {
     v <- lst$value
@@ -362,7 +281,7 @@ rd_trans_size <- function(lst) {
       size <- size + as.integer(object.size(v$intro))
     }
     for (i in seq_along(v$components)) {
-      size <- size + as.integer(object.size(v$components[[i]]))
+      size <- size + as.integer(object.size(v$components[[i]]$description))
     }
     if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
       size <- size + as.integer(object.size(v$outro))
@@ -376,6 +295,10 @@ rd_trans_size <- function(lst) {
   }
   if (!is.null(lst$examples)) {
     size <- size + as.integer(object.size(lst$examples))
+  }
+  if (context_size >= 1L) {
+    full_doc_text <- rd_flatten(lst)
+    size <- size + 2L * as.integer(object.size(full_doc_text))
   }
   size
 }
@@ -470,6 +393,7 @@ progress_bar_init <- function(total, format, envir = parent.frame()) {
       auto_terminate = FALSE,
       .envir = envir
     )
+    cli_progress_update(set = 0L, force = TRUE, .envir = envir)
   }
 }
 
@@ -479,22 +403,14 @@ progress_bar_update <- function(
   envir = parent.frame()
 ) {
   if (is_interactive()) {
-    if (is.null(obj)) {
-      set <- NULL
-    } else {
+    if (!is.null(obj)) {
       total_size <- .lang_env$size
       curr_progress <- as.integer(object.size(obj)) + .lang_env$progress
-      if (curr_progress > total_size) {
-        .lang_env$progress <- total_size
-      } else {
-        .lang_env$progress <- curr_progress
-      }
-      set <- .lang_env$progress
+      .lang_env$progress <- min(curr_progress, total_size)
     }
     if (!is.null(txt)) {
       envir$tag_label <- txt
     }
-    print(paste(txt, " - object size:", set))
-    cli_progress_update(set = set, .envir = envir)
+    cli_progress_update(set = .lang_env$progress, force = TRUE, .envir = envir)
   }
 }

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -103,6 +103,23 @@ rd_translate <- function(rd_content, lang) {
     lst[[sec_idx[[i]]]]$contents <- rd_field_translate(s$contents, lang, rs)
   }
 
+  # Examples — translate # comments only
+  if (!is.null(lst$examples)) {
+    section_no <- section_no + 1L
+    progress_bar_update("Examples", obj = lst$examples)
+    ex <- lst$examples
+    if (!is.null(ex$code_run)) {
+      lst$examples$code_run <- rd_examples_translate(ex$code_run, lang, rs)
+    }
+    if (!is.null(ex$code_dont_run)) {
+      lst$examples$code_dont_run <- rd_examples_translate(
+        ex$code_dont_run,
+        lang,
+        rs
+      )
+    }
+  }
+
   cli_progress_done()
   cli_alert_success("{.pkg lang} - {.emph Translation complete}")
 
@@ -124,6 +141,23 @@ rd_field_translate <- function(x, lang, rs) {
     },
     args = list(x = paste(x, collapse = "\n"), y = lang, z = add_prompt)
   )
+}
+
+rd_examples_translate <- function(code, lang, rs) {
+  lines <- strsplit(code, "\n", fixed = TRUE)[[1L]]
+  comment_idx <- which(substr(lines, 1L, 2L) == "# ")
+  if (length(comment_idx) == 0L) {
+    return(code)
+  }
+  comment_texts <- substr(lines[comment_idx], 3L, nchar(lines[comment_idx]))
+  translated <- rs$run(
+    function(x, language) {
+      mall::llm_vec_translate(x = x, language = language)
+    },
+    args = list(x = comment_texts, language = lang)
+  )
+  lines[comment_idx] <- paste0("# ", translated)
+  paste(lines, collapse = "\n")
 }
 
 rd_count_fields <- function(lst) {
@@ -154,6 +188,9 @@ rd_count_fields <- function(lst) {
     }
   }
   n <- n + length(which(nms == "section")) * 2L
+  if (!is.null(lst$examples)) {
+    n <- n + 1L
+  }
   n
 }
 

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -52,7 +52,7 @@ rd_translate <- function(rd_content, lang, context_size) {
 
   tag_label <- "Initializing..."
   progress_bar_init(
-    total = rd_trans_size(lst, context_size),
+    total = rd_count_fields(lst),
     format = "{pb_bar} {pb_percent} | {tag_label}"
   )
 
@@ -65,13 +65,13 @@ rd_translate <- function(rd_content, lang, context_size) {
       function(text, n) mall::llm_vec_summarize(text, max_words = n),
       args = list(text = full_doc_text, n = context_size)
     )
-    progress_bar_update("Context: Summarizing", obj = summary_en)
+    progress_bar_update("Context: Summarizing")
     progress_bar_update("Context: Translating summary")
     context_summary <- rs$run(
       function(x, lang) mall::llm_vec_translate(x, language = lang),
       args = list(x = summary_en, lang = lang)
     )
-    progress_bar_update("Context: Translating summary", obj = context_summary)
+    progress_bar_update("Context: Translating summary")
   } else {
     context_summary <- NULL
   }
@@ -94,7 +94,7 @@ rd_translate <- function(rd_content, lang, context_size) {
         rs,
         context_summary
       )
-      progress_bar_update(tag_to_label(field), obj = lst[[field]])
+      progress_bar_update(tag_to_label(field), done = TRUE)
     }
   }
 
@@ -108,10 +108,7 @@ rd_translate <- function(rd_content, lang, context_size) {
       rs,
       context_summary
     )
-    progress_bar_update(
-      glue("Argument: '{arg_name}'"),
-      obj = lst$arguments[[i]]$description
-    )
+    progress_bar_update(glue("Argument: '{arg_name}'"), done = TRUE)
   }
 
   # Value
@@ -120,7 +117,7 @@ rd_translate <- function(rd_content, lang, context_size) {
     if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
       progress_bar_update("Value")
       lst$value$intro <- rd_field_translate(v$intro, lang, rs, context_summary)
-      progress_bar_update("Value", obj = lst$value$intro)
+      progress_bar_update("Value", done = TRUE)
     }
     for (i in seq_along(v$components)) {
       comp_name <- v$components[[i]]$component
@@ -131,15 +128,12 @@ rd_translate <- function(rd_content, lang, context_size) {
         rs,
         context_summary
       )
-      progress_bar_update(
-        glue("Value: '{comp_name}'"),
-        obj = lst$value$components[[i]]$description
-      )
+      progress_bar_update(glue("Value: '{comp_name}'"), done = TRUE)
     }
     if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
       progress_bar_update("Value")
       lst$value$outro <- rd_field_translate(v$outro, lang, rs, context_summary)
-      progress_bar_update("Value", obj = lst$value$outro)
+      progress_bar_update("Value", done = TRUE)
     }
   }
 
@@ -159,7 +153,7 @@ rd_translate <- function(rd_content, lang, context_size) {
       rs,
       context_summary
     )
-    progress_bar_update(lbl, obj = lst[[sec_idx[[i]]]]$title)
+    progress_bar_update(lbl, done = TRUE)
     progress_bar_update(lbl)
     lst[[sec_idx[[i]]]]$contents <- rd_field_translate(
       s$contents,
@@ -167,7 +161,7 @@ rd_translate <- function(rd_content, lang, context_size) {
       rs,
       context_summary
     )
-    progress_bar_update(lbl, obj = lst[[sec_idx[[i]]]]$contents)
+    progress_bar_update(lbl, done = TRUE)
   }
 
   # Examples — translate # comments only
@@ -189,7 +183,7 @@ rd_translate <- function(rd_content, lang, context_size) {
         context_summary
       )
     }
-    progress_bar_update("Examples", obj = lst$examples)
+    progress_bar_update("Examples", done = TRUE)
   }
 
   cli_progress_done()
@@ -255,55 +249,8 @@ rd_examples_translate <- function(code, lang, rs, context_summary = NULL) {
   paste(lines, collapse = "\n")
 }
 
-rd_trans_size <- function(lst, context_size = 0L) {
-  nms <- names(lst)
-  size <- 0L
-  prose_fields <- c(
-    "title",
-    "description",
-    "details",
-    "note",
-    "author",
-    "references",
-    "seealso"
-  )
-  for (field in prose_fields) {
-    if (!is.null(lst[[field]])) {
-      size <- size + as.integer(object.size(lst[[field]]))
-    }
-  }
-  for (i in seq_along(lst$arguments)) {
-    size <- size + as.integer(object.size(lst$arguments[[i]]$description))
-  }
-  if (!is.null(lst$value)) {
-    v <- lst$value
-    if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
-      size <- size + as.integer(object.size(v$intro))
-    }
-    for (i in seq_along(v$components)) {
-      size <- size + as.integer(object.size(v$components[[i]]$description))
-    }
-    if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
-      size <- size + as.integer(object.size(v$outro))
-    }
-  }
-  sec_idx <- which(nms == "section")
-  for (i in seq_along(sec_idx)) {
-    s <- lst[[sec_idx[[i]]]]
-    size <- size + as.integer(object.size(s$title))
-    size <- size + as.integer(object.size(s$contents))
-  }
-  if (!is.null(lst$examples)) {
-    size <- size + as.integer(object.size(lst$examples))
-  }
-  if (context_size >= 1L) {
-    full_doc_text <- rd_flatten(lst)
-    size <- size + 2L * as.integer(object.size(full_doc_text))
-  }
-  size
-}
 
-rd_count_fields <- function(lst, context_size = 0L) {
+rd_count_fields <- function(lst) {
   nms <- names(lst)
   n <- 0L
   for (field in c(
@@ -333,9 +280,6 @@ rd_count_fields <- function(lst, context_size = 0L) {
   n <- n + length(which(nms == "section")) * 2L
   if (!is.null(lst$examples)) {
     n <- n + 1L
-  }
-  if (context_size >= 1L) {
-    n <- n + 2L
   }
   n
 }
@@ -385,8 +329,7 @@ is_interactive <- function() interactive()
 
 progress_bar_init <- function(total, format, envir = parent.frame()) {
   if (is_interactive()) {
-    .lang_env$size <- total
-    .lang_env$progress <- 0
+    .lang_env$progress <- 0L
     cli_progress_bar(
       total = total,
       format = format,
@@ -399,14 +342,12 @@ progress_bar_init <- function(total, format, envir = parent.frame()) {
 
 progress_bar_update <- function(
   txt = NULL,
-  obj = NULL,
+  done = FALSE,
   envir = parent.frame()
 ) {
   if (is_interactive()) {
-    if (!is.null(obj)) {
-      total_size <- .lang_env$size
-      curr_progress <- as.integer(object.size(obj)) + .lang_env$progress
-      .lang_env$progress <- min(curr_progress, total_size)
+    if (done) {
+      .lang_env$progress <- .lang_env$progress + 1L
     }
     if (!is.null(txt)) {
       envir$tag_label <- txt

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -51,28 +51,35 @@ rd_translate <- function(rd_content, lang, context_size) {
   nms <- names(lst)
 
   tag_label <- "Initializing..."
-  progress_bar_init(
-    total = rd_count_fields(lst),
-    format = "{pb_bar} {pb_percent} | {tag_label}"
-  )
 
   rs <- lang_rs_get()
 
   if (context_size >= 1L) {
     full_doc_text <- rd_flatten(lst)
-    progress_bar_update("Context: Summarizing")
+    progress_bar_init(
+      total = rd_trans_size(lst) +
+        as.integer(object.size(full_doc_text)) +
+        context_size * 8L,
+      format = "{pb_bar} {pb_percent} | {tag_label}"
+    )
+    progress_bar_update_text("Context: Summarizing")
     summary_en <- rs$run(
       function(text, n) mall::llm_vec_summarize(text, max_words = n),
       args = list(text = full_doc_text, n = context_size)
     )
-    progress_bar_update("Context: Summarizing")
-    progress_bar_update("Context: Translating summary")
+    progress_bar_update_done(full_doc_text)
+    progress_bar_update_text("Context: Translating summary")
     context_summary <- rs$run(
       function(x, lang) mall::llm_vec_translate(x, language = lang),
       args = list(x = summary_en, lang = lang)
     )
-    progress_bar_update("Context: Translating summary")
+    progress_bar_update_done(context_summary)
+    progress_bar_update_text("Translating...")
   } else {
+    progress_bar_init(
+      total = rd_trans_size(lst),
+      format = "{pb_bar} {pb_percent} | {tag_label}"
+    )
     context_summary <- NULL
   }
 
@@ -87,53 +94,53 @@ rd_translate <- function(rd_content, lang, context_size) {
     "seealso"
   )) {
     if (!is.null(lst[[field]])) {
-      progress_bar_update(tag_to_label(field))
+      progress_bar_update_text(tag_to_label(field))
       lst[[field]] <- rd_field_translate(
         lst[[field]],
         lang,
         rs,
         context_summary
       )
-      progress_bar_update(tag_to_label(field), done = TRUE)
+      progress_bar_update_done(lst[[field]])
     }
   }
 
   # Arguments
   for (i in seq_along(lst$arguments)) {
     arg_name <- lst$arguments[[i]]$argument
-    progress_bar_update(glue("Argument: '{arg_name}'"))
+    progress_bar_update_text(glue("Argument: '{arg_name}'"))
     lst$arguments[[i]]$description <- rd_field_translate(
       lst$arguments[[i]]$description,
       lang,
       rs,
       context_summary
     )
-    progress_bar_update(glue("Argument: '{arg_name}'"), done = TRUE)
+    progress_bar_update_done(lst$arguments[[i]]$description)
   }
 
   # Value
   if (!is.null(lst$value)) {
     v <- lst$value
     if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
-      progress_bar_update("Value")
+      progress_bar_update_text("Value")
       lst$value$intro <- rd_field_translate(v$intro, lang, rs, context_summary)
-      progress_bar_update("Value", done = TRUE)
+      progress_bar_update_done(lst$value$intro)
     }
     for (i in seq_along(v$components)) {
       comp_name <- v$components[[i]]$component
-      progress_bar_update(glue("Value: '{comp_name}'"))
+      progress_bar_update_text(glue("Value: '{comp_name}'"))
       lst$value$components[[i]]$description <- rd_field_translate(
         v$components[[i]]$description,
         lang,
         rs,
         context_summary
       )
-      progress_bar_update(glue("Value: '{comp_name}'"), done = TRUE)
+      progress_bar_update_done(lst$value$components[[i]]$description)
     }
     if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
-      progress_bar_update("Value")
+      progress_bar_update_text("Value")
       lst$value$outro <- rd_field_translate(v$outro, lang, rs, context_summary)
-      progress_bar_update("Value", done = TRUE)
+      progress_bar_update_done(lst$value$outro)
     }
   }
 
@@ -146,27 +153,27 @@ rd_translate <- function(rd_content, lang, context_size) {
       tag_full <- paste0(substr(tag_full, 1L, 17L), "...")
     }
     lbl <- glue("Section: '{tag_full}'")
-    progress_bar_update(lbl)
+    progress_bar_update_text(lbl)
     lst[[sec_idx[[i]]]]$title <- rd_field_translate(
       s$title,
       lang,
       rs,
       context_summary
     )
-    progress_bar_update(lbl, done = TRUE)
-    progress_bar_update(lbl)
+    progress_bar_update_done(lst[[sec_idx[[i]]]]$title)
+    progress_bar_update_text(lbl)
     lst[[sec_idx[[i]]]]$contents <- rd_field_translate(
       s$contents,
       lang,
       rs,
       context_summary
     )
-    progress_bar_update(lbl, done = TRUE)
+    progress_bar_update_done(lst[[sec_idx[[i]]]]$contents)
   }
 
   # Examples — translate # comments only
   if (!is.null(lst$examples)) {
-    progress_bar_update("Examples")
+    progress_bar_update_text("Examples")
     if (!is.null(lst$examples$code_run)) {
       lst$examples$code_run <- rd_examples_translate(
         lst$examples$code_run,
@@ -183,7 +190,7 @@ rd_translate <- function(rd_content, lang, context_size) {
         context_summary
       )
     }
-    progress_bar_update("Examples", done = TRUE)
+    progress_bar_update_done(lst$examples)
   }
 
   cli_progress_done()
@@ -250,6 +257,49 @@ rd_examples_translate <- function(code, lang, rs, context_summary = NULL) {
 }
 
 
+rd_trans_size <- function(lst) {
+  nms <- names(lst)
+  size <- 0L
+  for (field in c(
+    "title",
+    "description",
+    "details",
+    "note",
+    "author",
+    "references",
+    "seealso"
+  )) {
+    if (!is.null(lst[[field]])) {
+      size <- size + as.integer(object.size(lst[[field]]))
+    }
+  }
+  for (i in seq_along(lst$arguments)) {
+    size <- size + as.integer(object.size(lst$arguments[[i]]$description))
+  }
+  if (!is.null(lst$value)) {
+    v <- lst$value
+    if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
+      size <- size + as.integer(object.size(v$intro))
+    }
+    for (i in seq_along(v$components)) {
+      size <- size + as.integer(object.size(v$components[[i]]$description))
+    }
+    if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
+      size <- size + as.integer(object.size(v$outro))
+    }
+  }
+  sec_idx <- which(nms == "section")
+  for (i in seq_along(sec_idx)) {
+    s <- lst[[sec_idx[[i]]]]
+    size <- size + as.integer(object.size(s$title))
+    size <- size + as.integer(object.size(s$contents))
+  }
+  if (!is.null(lst$examples)) {
+    size <- size + as.integer(object.size(lst$examples))
+  }
+  size
+}
+
 rd_count_fields <- function(lst) {
   nms <- names(lst)
   n <- 0L
@@ -304,16 +354,9 @@ tag_to_label <- function(x) {
   tag_labels <- c(
     "title" = "Title",
     "description" = "Description",
-    "value" = "Value",
     "details" = "Details",
     "note" = "Note",
     "seealso" = "See Also",
-    "examples" = "Examples",
-    "arguments" = "Arguments",
-    "usage" = "Usage",
-    "output" = "Output",
-    "returns" = "Returns",
-    "return" = "Return",
     "author" = "Author",
     "references" = "References"
   )
@@ -329,6 +372,7 @@ is_interactive <- function() interactive()
 
 progress_bar_init <- function(total, format, envir = parent.frame()) {
   if (is_interactive()) {
+    .lang_env$total <- total
     .lang_env$progress <- 0L
     cli_progress_bar(
       total = total,
@@ -340,18 +384,19 @@ progress_bar_init <- function(total, format, envir = parent.frame()) {
   }
 }
 
-progress_bar_update <- function(
-  txt = NULL,
-  done = FALSE,
-  envir = parent.frame()
-) {
+progress_bar_update_text <- function(txt, envir = parent.frame()) {
   if (is_interactive()) {
-    if (done) {
-      .lang_env$progress <- .lang_env$progress + 1L
-    }
-    if (!is.null(txt)) {
-      envir$tag_label <- txt
-    }
+    envir$tag_label <- txt
+    cli_progress_update(set = .lang_env$progress, force = TRUE, .envir = envir)
+  }
+}
+
+progress_bar_update_done <- function(obj, envir = parent.frame()) {
+  if (is_interactive()) {
+    .lang_env$progress <- min(
+      .lang_env$progress + as.integer(object.size(obj)),
+      .lang_env$total
+    )
     cli_progress_update(set = .lang_env$progress, force = TRUE, .envir = envir)
   }
 }

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -271,7 +271,7 @@ rd_translate <- function(rd_content, lang, context_size) {
 
   if (!is.null(lst$examples)) {
     section_no <- section_no + 1L
-    progress_bar_update("Examples")
+    progress_bar_update("Examples", obj = lst$examples)
   }
 
   cli_progress_done()
@@ -373,6 +373,9 @@ rd_trans_size <- function(lst) {
     s <- lst[[sec_idx[[i]]]]
     size <- size + as.integer(object.size(s$title))
     size <- size + as.integer(object.size(s$contents))
+  }
+  if (!is.null(lst$examples)) {
+    size <- size + as.integer(object.size(lst$examples))
   }
   size
 }
@@ -491,6 +494,7 @@ progress_bar_update <- function(
     if (!is.null(txt)) {
       envir$tag_label <- txt
     }
+    print(paste(txt, " - object size:", set))
     cli_progress_update(set = set, .envir = envir)
   }
 }

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -1,6 +1,4 @@
-rd_translate <- function(rd_content, lang, context_size) {
-  rs <- callr::r_session$new()
-  on.exit(rs$close())
+lang_rs_refresh <- function(rs) {
   lang_args <- lang_use_impl(.is_internal = TRUE)
   use_args <- list(
     backend = lang_args[["backend"]],
@@ -15,6 +13,37 @@ rd_translate <- function(rd_content, lang, context_size) {
     function(x) rlang::exec(mall::llm_use, !!!x),
     args = list(x = use_args)
   )
+}
+
+lang_rs_hash <- function() {
+  s <- .lang_env$session
+  paste(s[["backend"]], s[["model"]], s[[".cache"]], collapse = "|")
+}
+
+lang_rs_get <- function() {
+  rs <- .lang_env$rs
+  if (!is.null(rs) && rs$is_alive()) {
+    if (rs$get_state() == "starting") {
+      rs$poll_process(5000L)
+    }
+    if (rs$get_state() == "idle") {
+      current_hash <- lang_rs_hash()
+      if (!identical(.lang_env$rs_hash, current_hash)) {
+        lang_rs_refresh(rs)
+        .lang_env$rs_hash <- current_hash
+      }
+      return(rs)
+    }
+  }
+  rs <- callr::r_session$new()
+  .lang_env$rs <- rs
+  lang_rs_refresh(rs)
+  .lang_env$rs_hash <- lang_rs_hash()
+  rs
+}
+
+rd_translate <- function(rd_content, lang, context_size) {
+  rs <- lang_rs_get()
 
   lst <- rd_to_list(rd_content)
   nms <- names(lst)
@@ -29,26 +58,41 @@ rd_translate <- function(rd_content, lang, context_size) {
 
   if (context_size >= 1L) {
     full_doc_text <- rd_flatten(lst)
-
     progress_bar_update("Context: Summarizing")
-    summary_en <- rs$run(
-      function(text, n) mall::llm_vec_summarize(text, max_words = n),
-      args = list(text = full_doc_text, n = context_size)
-    )
-    section_no <- section_no + 1L
-
-    progress_bar_update("Context: Translating summary")
+    # Summarize + translate in one IPC round-trip
     context_summary <- rs$run(
-      function(x, lang) mall::llm_vec_translate(x, language = lang),
-      args = list(x = summary_en, lang = lang)
+      function(text, n, lang) {
+        en_summary <- mall::llm_vec_summarize(text, max_words = n)
+        mall::llm_vec_translate(en_summary, language = lang)
+      },
+      args = list(text = full_doc_text, n = context_size, lang = lang)
     )
-    section_no <- section_no + 1L
+    section_no <- section_no + 2L
+    progress_bar_update("Context: Translating summary")
   } else {
     context_summary <- NULL
   }
 
-  # Prose scalar / vector fields
-  for (field in c(
+  # Build shared prompt once (all fields use the same context block)
+  context_block <- if (!is.null(context_summary)) {
+    paste0(
+      "For context, here is a short summary of the full help page in the target language:\n\n",
+      context_summary,
+      "\n\n"
+    )
+  } else {
+    ""
+  }
+  add_prompt <- paste(
+    context_block,
+    "Do not translate anything between single quotes.",
+    "Do not translate the words: NULL, TRUE, FALSE, NA, Nan.",
+    "Do not expand on the subject, simply translate the original text"
+  )
+
+  # --- Collect all translatable texts into one vector ---
+
+  prose_fields <- c(
     "title",
     "description",
     "details",
@@ -56,115 +100,171 @@ rd_translate <- function(rd_content, lang, context_size) {
     "author",
     "references",
     "seealso"
-  )) {
-    if (!is.null(lst[[field]])) {
-      lst[[field]] <- rd_field_translate(
-        lst[[field]],
-        lang,
-        rs,
-        context_summary
-      )
-      section_no <- section_no + 1L
-      progress_bar_update(tag_to_label(field), obj = lst[[field]])
-    }
-  }
+  )
+  prose_present <- prose_fields[
+    !vapply(lst[prose_fields], is.null, logical(1L))
+  ]
+  texts <- vapply(
+    prose_present,
+    function(f) paste(lst[[f]], collapse = "\n"),
+    character(1L)
+  )
 
-  # Arguments
-  for (i in seq_along(lst$arguments)) {
-    arg_name <- lst$arguments[[i]]$argument
-    lst$arguments[[i]]$description <- rd_field_translate(
-      lst$arguments[[i]]$description,
-      lang,
-      rs,
-      context_summary
+  arg_start <- length(texts) + 1L
+  texts <- c(
+    texts,
+    vapply(
+      lst$arguments,
+      function(a) paste(a$description, collapse = "\n"),
+      character(1L)
     )
-    section_no <- section_no + 1L
-    progress_bar_update(
-      glue("Argument: '{arg_name}'"),
-      obj = lst$arguments[[i]]
-    )
-  }
+  )
 
-  # Value
+  value_intro_pos <- NULL
+  value_comp_start <- NULL
+  value_outro_pos <- NULL
   if (!is.null(lst$value)) {
     v <- lst$value
     if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
-      lst$value$intro <- rd_field_translate(v$intro, lang, rs, context_summary)
-      section_no <- section_no + 1L
-      progress_bar_update("Value", obj = lst$value$intro)
+      value_intro_pos <- length(texts) + 1L
+      texts <- c(texts, paste(v$intro, collapse = "\n"))
     }
-    for (i in seq_along(v$components)) {
-      comp_name <- v$components[[i]]$component
-      lst$value$components[[i]]$description <- rd_field_translate(
-        v$components[[i]]$description,
-        lang,
-        rs,
-        context_summary
-      )
-      section_no <- section_no + 1L
-      progress_bar_update(
-        glue("Value: '{comp_name}'"),
-        obj = lst$value$components[[i]]
+    if (length(v$components) > 0L) {
+      value_comp_start <- length(texts) + 1L
+      texts <- c(
+        texts,
+        vapply(
+          v$components,
+          function(c) paste(c$description, collapse = "\n"),
+          character(1L)
+        )
       )
     }
     if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
-      lst$value$outro <- rd_field_translate(v$outro, lang, rs, context_summary)
-      section_no <- section_no + 1L
-      progress_bar_update("Value", obj = lst$value$outro)
+      value_outro_pos <- length(texts) + 1L
+      texts <- c(texts, paste(v$outro, collapse = "\n"))
     }
   }
 
-  # Named sections
   sec_idx <- which(nms == "section")
+  sec_labels <- character(length(sec_idx))
+  sec_title_pos <- integer(length(sec_idx))
+  sec_content_pos <- integer(length(sec_idx))
   for (i in seq_along(sec_idx)) {
     s <- lst[[sec_idx[[i]]]]
     tag_full <- s$title
-    if (nchar(tag_full) > 17) {
-      tag_full <- paste0(substr(tag_full, 1, 17), "...")
+    if (nchar(tag_full) > 17L) {
+      tag_full <- paste0(substr(tag_full, 1L, 17L), "...")
     }
-    lst[[sec_idx[[i]]]]$title <- rd_field_translate(
-      s$title,
-      lang,
-      rs,
-      context_summary
-    )
-    section_no <- section_no + 1L
-    progress_bar_update(
-      glue("Section: '{tag_full}'"),
-      obj = lst[[sec_idx[[i]]]]$title
-    )
-    lst[[sec_idx[[i]]]]$contents <- rd_field_translate(
-      s$contents,
-      lang,
-      rs,
-      context_summary
-    )
-    section_no <- section_no + 1L
-    progress_bar_update(
-      glue("Section: '{tag_full}'"),
-      obj = lst[[sec_idx[[i]]]]$contents
-    )
+    sec_labels[[i]] <- tag_full
+    sec_title_pos[[i]] <- length(texts) + 1L
+    texts <- c(texts, paste(s$title, collapse = "\n"))
+    sec_content_pos[[i]] <- length(texts) + 1L
+    texts <- c(texts, paste(s$contents, collapse = "\n"))
   }
 
-  # Examples — translate # comments only
+  ex_info <- list()
   if (!is.null(lst$examples)) {
-    ex <- lst$examples
-    if (!is.null(ex$code_run)) {
-      lst$examples$code_run <- rd_examples_translate(
-        ex$code_run,
-        lang,
-        rs,
-        context_summary
+    for (code_field in c("code_run", "code_dont_run")) {
+      if (!is.null(lst$examples[[code_field]])) {
+        lines <- strsplit(lst$examples[[code_field]], "\n", fixed = TRUE)[[1L]]
+        cidx <- which(substr(lines, 1L, 2L) == "# ")
+        if (length(cidx) > 0L) {
+          ex_info[[code_field]] <- list(
+            lines = lines,
+            cidx = cidx,
+            start = length(texts) + 1L,
+            n = length(cidx)
+          )
+          texts <- c(texts, substr(lines[cidx], 3L, nchar(lines[cidx])))
+        }
+      }
+    }
+  }
+
+  # --- One batch IPC call for all fields ---
+  if (length(texts) > 0L) {
+    translated <- rs$run(
+      function(x, lang, prompt) {
+        mall::llm_vec_translate(
+          x = x,
+          language = lang,
+          additional_prompt = prompt
+        )
+      },
+      args = list(x = texts, lang = lang, prompt = add_prompt)
+    )
+
+    # Distribute results back and update progress bar per field
+
+    for (k in seq_along(prose_present)) {
+      f <- prose_present[[k]]
+      lst[[f]] <- translated[[k]]
+      section_no <- section_no + 1L
+      progress_bar_update(tag_to_label(f), obj = lst[[f]])
+    }
+
+    for (i in seq_along(lst$arguments)) {
+      lst$arguments[[i]]$description <- translated[[arg_start + i - 1L]]
+      section_no <- section_no + 1L
+      progress_bar_update(
+        glue("Argument: '{lst$arguments[[i]]$argument}'"),
+        obj = lst$arguments[[i]]
       )
     }
-    if (!is.null(ex$code_dont_run)) {
-      lst$examples$code_dont_run <- rd_examples_translate(
-        ex$code_dont_run,
-        lang,
-        rs,
-        context_summary
+
+    if (!is.null(lst$value)) {
+      if (!is.null(value_intro_pos)) {
+        lst$value$intro <- translated[[value_intro_pos]]
+        section_no <- section_no + 1L
+        progress_bar_update("Value", obj = lst$value$intro)
+      }
+      if (!is.null(value_comp_start)) {
+        for (i in seq_along(lst$value$components)) {
+          comp_name <- lst$value$components[[i]]$component
+          lst$value$components[[i]]$description <- translated[[
+            value_comp_start + i - 1L
+          ]]
+          section_no <- section_no + 1L
+          progress_bar_update(
+            glue("Value: '{comp_name}'"),
+            obj = lst$value$components[[i]]
+          )
+        }
+      }
+      if (!is.null(value_outro_pos)) {
+        lst$value$outro <- translated[[value_outro_pos]]
+        section_no <- section_no + 1L
+        progress_bar_update("Value", obj = lst$value$outro)
+      }
+    }
+
+    for (i in seq_along(sec_idx)) {
+      lst[[sec_idx[[i]]]]$title <- translated[[sec_title_pos[[i]]]]
+      section_no <- section_no + 1L
+      progress_bar_update(
+        glue("Section: '{sec_labels[[i]]}'"),
+        obj = lst[[sec_idx[[i]]]]$title
+      )
+      lst[[sec_idx[[i]]]]$contents <- translated[[sec_content_pos[[i]]]]
+      section_no <- section_no + 1L
+      progress_bar_update(
+        glue("Section: '{sec_labels[[i]]}'"),
+        obj = lst[[sec_idx[[i]]]]$contents
       )
     }
+
+    for (code_field in names(ex_info)) {
+      info <- ex_info[[code_field]]
+      info$lines[info$cidx] <- paste0(
+        "# ",
+        translated[info$start:(info$start + info$n - 1L)]
+      )
+      lst$examples[[code_field]] <- paste(info$lines, collapse = "\n")
+    }
+  }
+
+  if (!is.null(lst$examples)) {
     section_no <- section_no + 1L
     progress_bar_update("Examples")
   }

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -6,14 +6,29 @@ rd_translate <- function(rd_content, lang, context_size) {
 
   rs <- lang_rs_get()
 
-  lst_size <- as.integer(object.size(lst[
-    !names(lst) %in% c("examples", "usage")
-  ]))
+  lst_size <- lst |>
+    lapply(object.size)
+  lst_size <- lst_size[!names(lst_size) %in% c("usage", "examples")]
+  lst_size <- lst_size |>
+    lapply(as.integer) |>
+    as.integer() |>
+    sum()
+
+  lst_comments_size <- lst$examples |>
+    lapply(strsplit, "\n") |>
+    lapply(unlist) |>
+    lapply(function(x) x[substr(x, 1, 1) == "#"]) |>
+    lapply(object.size) |>
+    as.integer() |>
+    sum()
+
+  lst_total <- lst_size +
+    lst_comments_size
 
   if (context_size >= 1L) {
     full_doc_text <- rd_flatten(lst)
     progress_bar_init(
-      total = lst_size +
+      total = lst_total +
         as.integer(object.size(full_doc_text)) +
         500,
       format = "{pb_bar} {pb_percent} | {tag_label}"
@@ -32,7 +47,7 @@ rd_translate <- function(rd_content, lang, context_size) {
     progress_bar_update_done(500)
   } else {
     progress_bar_init(
-      total = lst_size,
+      total = lst_total,
       format = "{pb_bar} {pb_percent} | {tag_label}"
     )
     context_summary <- NULL
@@ -79,6 +94,7 @@ rd_translate <- function(rd_content, lang, context_size) {
     if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
       progress_bar_update_text("Value")
       lst$value$intro <- rd_field_translate(v$intro, lang, rs, context_summary)
+      progress_bar_update_done(v$intro)
     }
     for (i in seq_along(v$components)) {
       comp_name <- v$components[[i]]$component

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -1,4 +1,4 @@
-rd_translate <- function(rd_content, lang) {
+rd_translate <- function(rd_content, lang, context_size) {
   rs <- callr::r_session$new()
   on.exit(rs$close())
   lang_args <- lang_use_impl(.is_internal = TRUE)
@@ -20,12 +20,32 @@ rd_translate <- function(rd_content, lang) {
   nms <- names(lst)
 
   section_no <- 0L
-  n_fields <- rd_count_fields(lst)
+  n_fields <- rd_count_fields(lst, context_size)
   tag_label <- ""
   progress_bar_init(
     total = rd_trans_size(lst),
     format = "[{section_no}/{n_fields}] {pb_bar} {pb_percent} | {tag_label}"
   )
+
+  if (context_size >= 1L) {
+    full_doc_text <- rd_flatten(lst)
+
+    progress_bar_update("Context: Summarizing")
+    summary_en <- rs$run(
+      function(text, n) mall::llm_vec_summarize(text, max_words = n),
+      args = list(text = full_doc_text, n = context_size)
+    )
+    section_no <- section_no + 1L
+
+    progress_bar_update("Context: Translating summary")
+    context_summary <- rs$run(
+      function(x, lang) mall::llm_vec_translate(x, language = lang),
+      args = list(x = summary_en, lang = lang)
+    )
+    section_no <- section_no + 1L
+  } else {
+    context_summary <- NULL
+  }
 
   # Prose scalar / vector fields
   for (field in c(
@@ -38,7 +58,12 @@ rd_translate <- function(rd_content, lang) {
     "seealso"
   )) {
     if (!is.null(lst[[field]])) {
-      lst[[field]] <- rd_field_translate(lst[[field]], lang, rs)
+      lst[[field]] <- rd_field_translate(
+        lst[[field]],
+        lang,
+        rs,
+        context_summary
+      )
       section_no <- section_no + 1L
       progress_bar_update(tag_to_label(field), obj = lst[[field]])
     }
@@ -50,7 +75,8 @@ rd_translate <- function(rd_content, lang) {
     lst$arguments[[i]]$description <- rd_field_translate(
       lst$arguments[[i]]$description,
       lang,
-      rs
+      rs,
+      context_summary
     )
     section_no <- section_no + 1L
     progress_bar_update(
@@ -63,7 +89,7 @@ rd_translate <- function(rd_content, lang) {
   if (!is.null(lst$value)) {
     v <- lst$value
     if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
-      lst$value$intro <- rd_field_translate(v$intro, lang, rs)
+      lst$value$intro <- rd_field_translate(v$intro, lang, rs, context_summary)
       section_no <- section_no + 1L
       progress_bar_update("Value", obj = lst$value$intro)
     }
@@ -72,7 +98,8 @@ rd_translate <- function(rd_content, lang) {
       lst$value$components[[i]]$description <- rd_field_translate(
         v$components[[i]]$description,
         lang,
-        rs
+        rs,
+        context_summary
       )
       section_no <- section_no + 1L
       progress_bar_update(
@@ -81,7 +108,7 @@ rd_translate <- function(rd_content, lang) {
       )
     }
     if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
-      lst$value$outro <- rd_field_translate(v$outro, lang, rs)
+      lst$value$outro <- rd_field_translate(v$outro, lang, rs, context_summary)
       section_no <- section_no + 1L
       progress_bar_update("Value", obj = lst$value$outro)
     }
@@ -95,13 +122,23 @@ rd_translate <- function(rd_content, lang) {
     if (nchar(tag_full) > 17) {
       tag_full <- paste0(substr(tag_full, 1, 17), "...")
     }
-    lst[[sec_idx[[i]]]]$title <- rd_field_translate(s$title, lang, rs)
+    lst[[sec_idx[[i]]]]$title <- rd_field_translate(
+      s$title,
+      lang,
+      rs,
+      context_summary
+    )
     section_no <- section_no + 1L
     progress_bar_update(
       glue("Section: '{tag_full}'"),
       obj = lst[[sec_idx[[i]]]]$title
     )
-    lst[[sec_idx[[i]]]]$contents <- rd_field_translate(s$contents, lang, rs)
+    lst[[sec_idx[[i]]]]$contents <- rd_field_translate(
+      s$contents,
+      lang,
+      rs,
+      context_summary
+    )
     section_no <- section_no + 1L
     progress_bar_update(
       glue("Section: '{tag_full}'"),
@@ -113,13 +150,19 @@ rd_translate <- function(rd_content, lang) {
   if (!is.null(lst$examples)) {
     ex <- lst$examples
     if (!is.null(ex$code_run)) {
-      lst$examples$code_run <- rd_examples_translate(ex$code_run, lang, rs)
+      lst$examples$code_run <- rd_examples_translate(
+        ex$code_run,
+        lang,
+        rs,
+        context_summary
+      )
     }
     if (!is.null(ex$code_dont_run)) {
       lst$examples$code_dont_run <- rd_examples_translate(
         ex$code_dont_run,
         lang,
-        rs
+        rs,
+        context_summary
       )
     }
     section_no <- section_no + 1L
@@ -135,8 +178,18 @@ rd_translate <- function(rd_content, lang) {
   tmp
 }
 
-rd_field_translate <- function(x, lang, rs) {
+rd_field_translate <- function(x, lang, rs, context_summary = NULL) {
+  context_block <- if (!is.null(context_summary)) {
+    paste0(
+      "For context, here is a short summary of the full help page in the target language:\n\n",
+      context_summary,
+      "\n\n"
+    )
+  } else {
+    ""
+  }
   add_prompt <- paste(
+    context_block,
     "Do not translate anything between single quotes.",
     "Do not translate the words: NULL, TRUE, FALSE, NA, Nan.",
     "Do not expand on the subject, simply translate the original text"
@@ -149,18 +202,31 @@ rd_field_translate <- function(x, lang, rs) {
   )
 }
 
-rd_examples_translate <- function(code, lang, rs) {
+rd_examples_translate <- function(code, lang, rs, context_summary = NULL) {
   lines <- strsplit(code, "\n", fixed = TRUE)[[1L]]
   comment_idx <- which(substr(lines, 1L, 2L) == "# ")
   if (length(comment_idx) == 0L) {
     return(code)
   }
+  context_block <- if (!is.null(context_summary)) {
+    paste0(
+      "For context, here is a short summary of the full help page in the target language:\n\n",
+      context_summary,
+      "\n\n"
+    )
+  } else {
+    ""
+  }
   comment_texts <- substr(lines[comment_idx], 3L, nchar(lines[comment_idx]))
   translated <- rs$run(
-    function(x, language) {
-      mall::llm_vec_translate(x = x, language = language)
+    function(x, language, context) {
+      mall::llm_vec_translate(
+        x = x,
+        language = language,
+        additional_prompt = context
+      )
     },
-    args = list(x = comment_texts, language = lang)
+    args = list(x = comment_texts, language = lang, context = context_block)
   )
   lines[comment_idx] <- paste0("# ", translated)
   paste(lines, collapse = "\n")
@@ -206,7 +272,7 @@ rd_trans_size <- function(lst) {
   size
 }
 
-rd_count_fields <- function(lst) {
+rd_count_fields <- function(lst, context_size = 0L) {
   nms <- names(lst)
   n <- 0L
   for (field in c(
@@ -236,6 +302,9 @@ rd_count_fields <- function(lst) {
   n <- n + length(which(nms == "section")) * 2L
   if (!is.null(lst$examples)) {
     n <- n + 1L
+  }
+  if (context_size >= 1L) {
+    n <- n + 2L
   }
   n
 }

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -41,7 +41,6 @@ lang_rs_get <- function() {
   }
   rs <- callr::r_session$new()
   .lang_env$rs <- rs
-  rs$poll_process(10000L)
   lang_rs_refresh(rs)
   .lang_env$rs_hash <- lang_rs_hash()
   rs

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -19,10 +19,12 @@ rd_translate <- function(rd_content, lang) {
   lst <- rd_to_list(rd_content)
   nms <- names(lst)
 
+  section_no <- 0L
+  n_fields <- rd_count_fields(lst)
   tag_label <- ""
   progress_bar_init(
-    total = rd_count_fields(lst),
-    format = "[{pb_current}/{pb_total}] {pb_bar} {pb_percent} | {tag_label}"
+    total = as.integer(object.size(lst)),
+    format = "[{section_no}/{n_fields}] {pb_bar} {pb_percent} | {tag_label}"
   )
 
   # Prose scalar / vector fields
@@ -36,7 +38,8 @@ rd_translate <- function(rd_content, lang) {
     "seealso"
   )) {
     if (!is.null(lst[[field]])) {
-      progress_bar_update(tag_to_label(field))
+      section_no <- section_no + 1L
+      progress_bar_update(tag_to_label(field), obj = lst[[field]])
       lst[[field]] <- rd_field_translate(lst[[field]], lang, rs)
     }
   }
@@ -44,7 +47,11 @@ rd_translate <- function(rd_content, lang) {
   # Arguments
   for (i in seq_along(lst$arguments)) {
     arg_name <- lst$arguments[[i]]$argument
-    progress_bar_update(glue("Argument: '{arg_name}'"))
+    section_no <- section_no + 1L
+    progress_bar_update(
+      glue("Argument: '{arg_name}'"),
+      obj = lst$arguments[[i]]$description
+    )
     lst$arguments[[i]]$description <- rd_field_translate(
       lst$arguments[[i]]$description,
       lang,
@@ -56,12 +63,17 @@ rd_translate <- function(rd_content, lang) {
   if (!is.null(lst$value)) {
     v <- lst$value
     if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
-      progress_bar_update("Value")
+      section_no <- section_no + 1L
+      progress_bar_update("Value", obj = v$intro)
       lst$value$intro <- rd_field_translate(v$intro, lang, rs)
     }
     for (i in seq_along(v$components)) {
       comp_name <- v$components[[i]]$component
-      progress_bar_update(glue("Value: '{comp_name}'"))
+      section_no <- section_no + 1L
+      progress_bar_update(
+        glue("Value: '{comp_name}'"),
+        obj = v$components[[i]]$description
+      )
       lst$value$components[[i]]$description <- rd_field_translate(
         v$components[[i]]$description,
         lang,
@@ -69,7 +81,8 @@ rd_translate <- function(rd_content, lang) {
       )
     }
     if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
-      progress_bar_update("Value")
+      section_no <- section_no + 1L
+      progress_bar_update("Value", obj = v$outro)
       lst$value$outro <- rd_field_translate(v$outro, lang, rs)
     }
   }
@@ -82,9 +95,11 @@ rd_translate <- function(rd_content, lang) {
     if (nchar(tag_full) > 17) {
       tag_full <- paste0(substr(tag_full, 1, 17), "...")
     }
-    progress_bar_update(glue("Section: '{tag_full}'"))
+    section_no <- section_no + 1L
+    progress_bar_update(glue("Section: '{tag_full}'"), obj = s$title)
     lst[[sec_idx[[i]]]]$title <- rd_field_translate(s$title, lang, rs)
-    progress_bar_update(glue("Section: '{tag_full}'"))
+    section_no <- section_no + 1L
+    progress_bar_update(glue("Section: '{tag_full}'"), obj = s$contents)
     lst[[sec_idx[[i]]]]$contents <- rd_field_translate(s$contents, lang, rs)
   }
 

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -33,13 +33,13 @@ rd_translate <- function(rd_content, lang, context_size) {
         500,
       format = "{pb_bar} {pb_percent} | {tag_label}"
     )
-    progress_bar_update_text("Context: Summarizing")
+    progress_bar_update_text("Creating Context - Summarizing")
     summary_en <- rs$run(
       function(text, n) mall::llm_vec_summarize(text, max_words = n),
       args = list(text = full_doc_text, n = context_size)
     )
     progress_bar_update_done(full_doc_text)
-    progress_bar_update_text("Context: Translating summary")
+    progress_bar_update_text("Creating Context - Translating")
     context_summary <- rs$run(
       function(x, lang) mall::llm_vec_translate(x, language = lang),
       args = list(x = summary_en, lang = lang)
@@ -78,7 +78,7 @@ rd_translate <- function(rd_content, lang, context_size) {
   # Arguments
   for (i in seq_along(lst$arguments)) {
     arg_name <- lst$arguments[[i]]$argument
-    progress_bar_update_text(glue("Argument: '{arg_name}'"))
+    progress_bar_update_text(glue("Arguments - '{arg_name}'"))
     lst$arguments[[i]]$description <- rd_field_translate(
       lst$arguments[[i]]$description,
       lang,
@@ -92,13 +92,13 @@ rd_translate <- function(rd_content, lang, context_size) {
   if (!is.null(lst$value)) {
     v <- lst$value
     if (!is.null(v$intro) && nzchar(trimws(v$intro))) {
-      progress_bar_update_text("Value")
+      progress_bar_update_text("Values")
       lst$value$intro <- rd_field_translate(v$intro, lang, rs, context_summary)
       progress_bar_update_done(v$intro)
     }
     for (i in seq_along(v$components)) {
       comp_name <- v$components[[i]]$component
-      progress_bar_update_text(glue("Value: '{comp_name}'"))
+      progress_bar_update_text(glue("Values - '{comp_name}'"))
       lst$value$components[[i]]$description <- rd_field_translate(
         v$components[[i]]$description,
         lang,
@@ -108,7 +108,7 @@ rd_translate <- function(rd_content, lang, context_size) {
       progress_bar_update_done(lst$value$components[[i]])
     }
     if (!is.null(v$outro) && nzchar(trimws(v$outro))) {
-      progress_bar_update_text("Value")
+      progress_bar_update_text("Values")
       lst$value$outro <- rd_field_translate(v$outro, lang, rs, context_summary)
       progress_bar_update_done(v$outro)
     }
@@ -122,7 +122,7 @@ rd_translate <- function(rd_content, lang, context_size) {
     if (nchar(tag_full) > 17L) {
       tag_full <- paste0(substr(tag_full, 1L, 17L), "...")
     }
-    lbl <- glue("Section: '{tag_full}'")
+    lbl <- glue("Sections - '{tag_full}'")
     progress_bar_update_text(lbl)
     lst[[sec_idx[[i]]]]$title <- rd_field_translate(
       s$title,
@@ -330,9 +330,9 @@ tag_to_label <- function(x) {
     "title" = "Title",
     "description" = "Description",
     "details" = "Details",
-    "note" = "Note",
+    "note" = "Notes",
     "seealso" = "See Also",
-    "author" = "Author",
+    "author" = "Authors",
     "references" = "References"
   )
   match <- tag_labels[names(tag_labels) == x]

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -1,10 +1,14 @@
 lang_rs_refresh <- function(rs) {
   lang_args <- lang_use_impl(.is_internal = TRUE)
-  use_args <- list(
-    backend = lang_args[["backend"]],
-    model = lang_args[["model"]],
-    .cache = lang_args[[".cache"]]
-  )
+  backend <- lang_args[["backend"]]
+  use_args <- list(.cache = lang_args[[".cache"]])
+  if (!is.null(backend)) {
+    use_args[["backend"]] <- backend
+  }
+  # Chat objects have their model built in; passing model separately is an error
+  if (!inherits(backend, "Chat")) {
+    use_args[["model"]] <- lang_args[["model"]]
+  }
   args <- lang_args[["args"]]
   if (length(args) > 0) {
     use_args <- c(use_args, args)

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -41,6 +41,7 @@ lang_rs_get <- function() {
   }
   rs <- callr::r_session$new()
   .lang_env$rs <- rs
+  rs$poll_process(10000L)
   lang_rs_refresh(rs)
   .lang_env$rs_hash <- lang_rs_hash()
   rs
@@ -63,16 +64,17 @@ rd_translate <- function(rd_content, lang, context_size) {
   if (context_size >= 1L) {
     full_doc_text <- rd_flatten(lst)
     progress_bar_update("Context: Summarizing")
-    # Summarize + translate in one IPC round-trip
-    context_summary <- rs$run(
-      function(text, n, lang) {
-        en_summary <- mall::llm_vec_summarize(text, max_words = n)
-        mall::llm_vec_translate(en_summary, language = lang)
-      },
-      args = list(text = full_doc_text, n = context_size, lang = lang)
+    summary_en <- rs$run(
+      function(text, n) mall::llm_vec_summarize(text, max_words = n),
+      args = list(text = full_doc_text, n = context_size)
     )
-    section_no <- section_no + 2L
+    section_no <- section_no + 1L
     progress_bar_update("Context: Translating summary")
+    context_summary <- rs$run(
+      function(x, lang) mall::llm_vec_translate(x, language = lang),
+      args = list(x = summary_en, lang = lang)
+    )
+    section_no <- section_no + 1L
   } else {
     context_summary <- NULL
   }

--- a/README.Rmd
+++ b/README.Rmd
@@ -74,9 +74,16 @@ alt="Screenshot of the lm function's help page in Spanish"/>
 
 After setup, simply use `?` to trigger and display the translated documentation.
 During translation, `lang` will display its progress by showing which section
-of the documentation is currently translating. During the R session, if you
-request the same R function's help more than one time then `lang` will use
-its cached results, which will run immediately. 
+of the documentation is currently translating. Because each section of a help
+page is translated independently, the LLM can lose track of the broader topic
+and produce inconsistent or out-of-context translations. To address this,
+`lang` first summarizes the full help page in English, translates that summary
+into the target language, and then uses it as context when translating each
+individual section. You can control the length of this summary with the
+`context_size` argument in `lang_use()` or `lang_help()` — set it to `0` to
+disable it, or increase it to give the LLM more context. During the R session,
+if you request the same R function's help more than one time then `lang` will
+use its cached results, which will run immediately.
 
 R enforces the printed names of each section, so they cannot be
 translated. This means that titles such as "Description", "Usage" and "Arguments" 
@@ -158,27 +165,40 @@ lang::lang_use(
 
 If `lang` becomes a regular part of your workflow, and running `lang_use()` at
 the beginning of every R session becomes cumbersome, then consider letting R
-connect at start up. 
+connect at start up.
 
 If present, the *.Rprofile* file runs at the beginning of any R session. If you
-wish to automatically set the model and language to use, add a call to `llm_use()`
+wish to automatically set the model and language to use, add a call to `lang_use()`
 to this file.  You can call `usethis::edit_r_profile()` to open your .Rprofile
-file so you can add the option. 
+file so you can add the option.
 
-Here is an example of such a call that could be used in the .Rprofile file:
+Here is an example using Ollama:
 
 ```r
 lang::lang_use(
-  backend = "ollama", 
-  model = "llama3.2", 
-  .cache = "~/help-translations/", 
+  backend = "ollama",
+  model = "llama3.2",
+  .cache = "~/help-translations/",
   .lang = "spanish",
   .silent = TRUE
   )
 ```
 
-In the example, we set `.silent` to `TRUE` so that there is no message every time 
-the R session is restarted. 
+And here is an example using an `ellmer` chat object:
+
+```r
+lang::lang_use(
+  backend = ellmer::chat_openai(model = "gpt-4o"),
+  .cache = "~/help-translations/",
+  .lang = "spanish",
+  .silent = TRUE
+  )
+```
+
+In both examples, `.silent` is set to `TRUE` so that there is no message every
+time the R session is restarted. The `.cache` argument points to a fixed folder
+so that translations persist across sessions. You can also set `.context_size`
+here to control how much context is prepended to each field's translation prompt.
 
 ## Considerations
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -25,7 +25,6 @@ lang_use(backend = chat, .lang = "spanish")
 [![R-CMD-check](https://github.com/mlverse/lang/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/mlverse/lang/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/mlverse/lang/branch/main/graph/badge.svg)](https://app.codecov.io/gh/mlverse/lang?branch=main)
 [![CRAN status](https://www.r-pkg.org/badges/version/lang)](https://CRAN.R-project.org/package=lang)
-[![Codecov test coverage](https://codecov.io/gh/mlverse/lang/graph/badge.svg)](https://app.codecov.io/gh/mlverse/lang)
 <!-- badges: end -->
 
 Use an **LLM to translate a function's help documentation on the fly**. `lang` 
@@ -56,8 +55,8 @@ In order to work, `lang` needs two things:
   
   1. A target language (e.g.: Spanish, French, Korean)
 
-These two can be defined using `lang_use()`.  For example,  the following code
-shows  how to use OpenAI's GPT-4o model to translate `lm()`'s help  into Spanish:
+These two can be defined using `lang_use()`. For example, the following code
+shows how to use OpenAI's GPT-4o model to translate `lm()`'s help into Spanish:
 
 ```r
 library(lang)
@@ -67,12 +66,15 @@ chat <- ellmer::chat_openai(model = "gpt-4o")
 lang_use(backend = chat, .lang = "spanish")
 
 ?lm
-#> [1/7] ■■                                 4% | Title
+#> ■■                                 4% | Title
 ```
 <img src="man/figures/lm-spanish.png" align="center" width="100%"
 alt="Screenshot of the lm function's help page in Spanish"/>
 
 After setup, simply use `?` to trigger and display the translated documentation.
+Note that R enforces the printed names of each section, so titles such as
+"Description", "Usage", and "Arguments" will always remain untranslated.
+
 During translation, `lang` will display its progress by showing which section
 of the documentation is currently translating. Because each section of a help
 page is translated independently, the LLM can lose track of the broader topic
@@ -85,31 +87,27 @@ disable it, or increase it to give the LLM more context. During the R session,
 if you request the same R function's help more than one time then `lang` will
 use its cached results, which will run immediately.
 
-R enforces the printed names of each section, so they cannot be
-translated. This means that titles such as "Description", "Usage" and "Arguments" 
-will always remain untranslated. 
-
 
 ### LLM connections
 
 There are two ways to define the LLM in `lang_use()`:
 
-1. Use an  [`ellmer`](https://ellmer.tidyverse.org/) chat object: 
+1. Use an [`ellmer`](https://ellmer.tidyverse.org/) chat object:
 
     ```r
     lang_use(backend = ellmer::chat_openai(model = "gpt-4o"))
     ```
 
-1. Use local LLMs available through [Ollama](https://ollama.com/). Pass `"ollama"` 
-as the `backend` argument, and specify which installed  model to use:
+1. Use local LLMs available through [Ollama](https://ollama.com/). Pass `"ollama"`
+as the `backend` argument, and specify which installed model to use:
 
     ```r
     lang_use(backend = "ollama", model = "llama3.2", seed = 100)
     ```
-    
-    Under the hood, `lang` uses the  [`ollamar`](https://hauselin.github.io/ollama-r/) 
-    package to integrate with Ollama. Any additional arguments, such as `seed` 
-    as shown above, will be passed as-is to `ollamar`'s `chat()` function. 
+
+    Under the hood, `lang` uses the [`ollamar`](https://hauselin.github.io/ollama-r/)
+    package to integrate with Ollama. Any additional arguments, such as `seed`
+    as shown above, will be passed as-is to `ollamar`'s `chat()` function.
 
 ### Target language
 
@@ -121,11 +119,11 @@ it will translate to:
 1. `LANGUAGE` environment variable
 1. `LANG` environment variable
 
-It is likely that your `LANG` variable  already defaults to your locale. 
-For example, mine is set to: `en_US.UTF-8` (That means English, United States). 
-For someone in France, the locale would be  something such as `fr_FR.UTF-8`. 
-Llama3.2, recognizes these UTF locales, and using `lang`, calling `?` will 
-result in translating the function's help documentation into French. 
+It is likely that your `LANG` variable already defaults to your locale.
+For example, mine is set to: `en_US.UTF-8` (that means English, United States).
+For someone in France, the locale would be something such as `fr_FR.UTF-8`.
+Llama3.2 recognizes these UTF locales, and using `lang`, calling `?` will
+result in translating the function's help documentation into French.
 
 If both environment variables are set, and are different from each other, 
 `lang` will display a one-time message indicating which value it will use. 
@@ -133,7 +131,7 @@ If the target language is English, `lang` will re-route help calls back to base
 R.
 
 To check the current target language at any point during the R session, 
-simply run: `lang_use()`,  with no arguments, and it will print out the 
+simply run: `lang_use()`, with no arguments, and it will print out the
 current settings, which include language:
 
 ```{r}
@@ -198,7 +196,7 @@ lang::lang_use(
 In both examples, `.silent` is set to `TRUE` so that there is no message every
 time the R session is restarted. The `.cache` argument points to a fixed folder
 so that translations persist across sessions. You can also set `.context_size`
-here to control how much context is prepended to each field's translation prompt.
+here to control how much context the LLM receives when translating each section.
 
 ## Considerations
 
@@ -212,7 +210,7 @@ translation could go a long way with someone who is struggling to understand
 how to use a specific function in a package and may also struggle with the
 English language.
 
-### Debug
+### Debugging
 
 If the original English help page displays, check your environment variables:
 
@@ -228,7 +226,7 @@ then no translation will occur.
 If this is your case, set the `LANGUAGE` variable to your preference. You can
 use the full language name, such as 'spanish', or 'french', etc.  You can use
 `Sys.setenv(LANGUAGE = "[my language]")`, or, for a more permanent solution, 
-add the entry to your your .Renviron file (`usethis::edit_r_environ()`). 
+add the entry to your .Renviron file (`usethis::edit_r_environ()`).
 
 ### Interaction with `mall`
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
 coverage](https://codecov.io/gh/mlverse/lang/branch/main/graph/badge.svg)](https://app.codecov.io/gh/mlverse/lang?branch=main)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/lang)](https://CRAN.R-project.org/package=lang)
-[![Codecov test
-coverage](https://codecov.io/gh/mlverse/lang/graph/badge.svg)](https://app.codecov.io/gh/mlverse/lang)
 <!-- badges: end -->
 
 Use an **LLM to translate a function’s help documentation on the fly**.
@@ -56,22 +54,29 @@ chat <- ellmer::chat_openai(model = "gpt-4o")
 lang_use(backend = chat, .lang = "spanish")
 
 ?lm
-#> [1/7] ■■                                 4% | Title
+#> ■■                                 4% | Title
 ```
 
 <img src="man/figures/lm-spanish.png" align="center" width="100%"
 alt="Screenshot of the lm function's help page in Spanish"/>
 
 After setup, simply use `?` to trigger and display the translated
-documentation. During translation, `lang` will display its progress by
-showing which section of the documentation is currently translating.
-During the R session, if you request the same R function’s help more
-than one time then `lang` will use its cached results, which will run
-immediately.
+documentation. Note that R enforces the printed names of each section,
+so titles such as “Description”, “Usage”, and “Arguments” will always
+remain untranslated.
 
-R enforces the printed names of each section, so they cannot be
-translated. This means that titles such as “Description”, “Usage” and
-“Arguments” will always remain untranslated.
+During translation, `lang` will display its progress by showing which
+section of the documentation is currently translating. Because each
+section of a help page is translated independently, the LLM can lose
+track of the broader topic and produce inconsistent or out-of-context
+translations. To address this, `lang` first summarizes the full help
+page in English, translates that summary into the target language, and
+then uses it as context when translating each individual section. You
+can control the length of this summary with the `context_size` argument
+in `lang_use()` or `lang_help()` — set it to `0` to disable it, or
+increase it to give the LLM more context. During the R session, if you
+request the same R function’s help more than one time then `lang` will
+use its cached results, which will run immediately.
 
 ### LLM connections
 
@@ -106,9 +111,9 @@ language it will translate to:
 3.  `LANG` environment variable
 
 It is likely that your `LANG` variable already defaults to your locale.
-For example, mine is set to: `en_US.UTF-8` (That means English, United
+For example, mine is set to: `en_US.UTF-8` (that means English, United
 States). For someone in France, the locale would be something such as
-`fr_FR.UTF-8`. Llama3.2, recognizes these UTF locales, and using `lang`,
+`fr_FR.UTF-8`. Llama3.2 recognizes these UTF locales, and using `lang`,
 calling `?` will result in translating the function’s help documentation
 into French.
 
@@ -155,25 +160,38 @@ then consider letting R connect at start up.
 
 If present, the *.Rprofile* file runs at the beginning of any R session.
 If you wish to automatically set the model and language to use, add a
-call to `llm_use()` to this file. You can call
+call to `lang_use()` to this file. You can call
 `usethis::edit_r_profile()` to open your .Rprofile file so you can add
 the option.
 
-Here is an example of such a call that could be used in the .Rprofile
-file:
+Here is an example using Ollama:
 
 ``` r
 lang::lang_use(
-  backend = "ollama", 
-  model = "llama3.2", 
-  .cache = "~/help-translations/", 
+  backend = "ollama",
+  model = "llama3.2",
+  .cache = "~/help-translations/",
   .lang = "spanish",
   .silent = TRUE
   )
 ```
 
-In the example, we set `.silent` to `TRUE` so that there is no message
-every time the R session is restarted.
+And here is an example using an `ellmer` chat object:
+
+``` r
+lang::lang_use(
+  backend = ellmer::chat_openai(model = "gpt-4o"),
+  .cache = "~/help-translations/",
+  .lang = "spanish",
+  .silent = TRUE
+  )
+```
+
+In both examples, `.silent` is set to `TRUE` so that there is no message
+every time the R session is restarted. The `.cache` argument points to a
+fixed folder so that translations persist across sessions. You can also
+set `.context_size` here to control how much context the LLM receives
+when translating each section.
 
 ## Considerations
 
@@ -187,14 +205,14 @@ even an imperfect translation could go a long way with someone who is
 struggling to understand how to use a specific function in a package and
 may also struggle with the English language.
 
-### Debug
+### Debugging
 
 If the original English help page displays, check your environment
 variables:
 
 ``` r
 Sys.getenv("LANG")
-#> [1] "en_US.UTF-8"
+#> [1] ""
 Sys.getenv("LANGUAGE")
 #> [1] ""
 ```
@@ -206,7 +224,7 @@ to `en_...` then no translation will occur.
 If this is your case, set the `LANGUAGE` variable to your preference.
 You can use the full language name, such as ‘spanish’, or ‘french’, etc.
 You can use `Sys.setenv(LANGUAGE = "[my language]")`, or, for a more
-permanent solution, add the entry to your your .Renviron file
+permanent solution, add the entry to your .Renviron file
 (`usethis::edit_r_environ()`).
 
 ### Interaction with `mall`

--- a/man/help.Rd
+++ b/man/help.Rd
@@ -25,8 +25,7 @@ to search for the help topic. If NULL, search all packages.}
 \item{e2}{Second argument to pass along to \verb{utils::}?``.}
 }
 \description{
-The \verb{?} and \code{help} functions are replacements for functions of the
-same name in the utils package. If the LANG environment variable is not set
-to English, it will activate the translation to whatever language LANG is
-set to.
+The \verb{?} and \code{help} functions are drop-in replacements for those in the
+utils package. They automatically translate help to the language specified
+by the \code{LANG} or \code{LANGUAGE} environment variables, or by \code{lang_use()}.
 }

--- a/man/lang-package.Rd
+++ b/man/lang-package.Rd
@@ -22,6 +22,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Edgar Ruiz \email{edgar@posit.co}
 
+Authors:
+\itemize{
+  \item Edgar Ruiz \email{edgar@posit.co}
+}
+
 Other contributors:
 \itemize{
   \item Posit Software, PBC (\href{https://ror.org/03wc8by49}{ROR}) [copyright holder, funder]

--- a/man/lang_help.Rd
+++ b/man/lang_help.Rd
@@ -13,15 +13,15 @@ lang_help(
 )
 }
 \arguments{
-\item{topic}{A character vector of the topic to search for.}
+\item{topic}{A character string specifying the help topic to translate.}
 
 \item{package}{The R package to look for the topic, if not provided the
 function will attempt to find the topic based on the loaded packages.}
 
 \item{lang}{A character vector language to translate the topic to}
 
-\item{context_size}{Maximum number of words for the context summary prepended
-to every field's translation prompt. Set to \code{0} to disable context-aware
+\item{context_size}{Maximum number of words for the context summary included
+with each translation request. Set to \code{0} to disable context-aware
 translation. When \code{NULL}, the value set via \code{lang_use()} is used (default
 \code{100}).}
 

--- a/man/lang_help.Rd
+++ b/man/lang_help.Rd
@@ -4,7 +4,13 @@
 \alias{lang_help}
 \title{Translates help documentation to another language}
 \usage{
-lang_help(topic, package = NULL, lang = NULL, type = getOption("help_type"))
+lang_help(
+  topic,
+  package = NULL,
+  lang = NULL,
+  context_size = NULL,
+  type = getOption("help_type")
+)
 }
 \arguments{
 \item{topic}{A character vector of the topic to search for.}
@@ -13,6 +19,11 @@ lang_help(topic, package = NULL, lang = NULL, type = getOption("help_type"))
 function will attempt to find the topic based on the loaded packages.}
 
 \item{lang}{A character vector language to translate the topic to}
+
+\item{context_size}{Maximum number of words for the context summary prepended
+to every field's translation prompt. Set to \code{0} to disable context-aware
+translation. When \code{NULL}, the value set via \code{lang_use()} is used (default
+\code{100}).}
 
 \item{type}{Produce "html" or "text" output for the help. It defaults to
 \code{getOption("help_type")}}

--- a/man/lang_use.Rd
+++ b/man/lang_use.Rd
@@ -16,24 +16,23 @@ lang_use(
 }
 \arguments{
 \item{backend}{"ollama" or an \code{ellmer} \code{Chat} object. If using "ollama",
-\code{mall} will use is out-of-the-box integration with that back-end. Defaults
-to "ollama".}
+\code{lang} provides built-in support via the \code{ollamar} package. Defaults to
+"ollama".}
 
 \item{model}{The name of model supported by the back-end provider}
 
-\item{.cache}{The path to save model results, so they can be re-used if
-the same operation is ran again. To turn off, set this argument to an empty
-character: \code{""}. It defaults to a temp folder. If this argument is left
-\code{NULL} when calling this function, no changes to the path will be made.}
+\item{.cache}{Character path where translations are cached. Set to \code{""} to
+disable caching. When \code{NULL}, the current session value is kept unchanged.
+Defaults to a temporary folder.}
 
 \item{.lang}{Target language to translate to. This will override values found
 in the LANG and LANGUAGE environment variables.}
 
-\item{.context_size}{Maximum number of words for the context summary that is
-prepended to every field's translation prompt. Set to \code{0} to disable
-context-aware translation. Defaults to \code{100}.}
+\item{.context_size}{Maximum number of words for the context summary
+included with each translation request. Set to \code{0} to disable context-aware
+translation. Defaults to \code{100}.}
 
-\item{.silent}{Boolean flag that controls if there is or not output to the
+\item{.silent}{Boolean flag that controls whether there is output to the
 console. Defaults to FALSE.}
 
 \item{...}{Additional arguments that this function will pass down to the
@@ -41,8 +40,8 @@ integrating function. In the case of Ollama, it will pass those arguments to
 \code{ollamar::chat()}.}
 }
 \value{
-Console output of the current LLM setup to be used during the
-R session.
+Invisibly returns \code{NULL}. Prints the current configuration to the
+console.
 }
 \description{
 Allows us to specify the back-end provider, model to use during the current

--- a/man/lang_use.Rd
+++ b/man/lang_use.Rd
@@ -9,6 +9,7 @@ lang_use(
   model = NULL,
   .cache = NULL,
   .lang = NULL,
+  .context_size = NULL,
   .silent = FALSE,
   ...
 )
@@ -27,6 +28,10 @@ character: \code{""}. It defaults to a temp folder. If this argument is left
 
 \item{.lang}{Target language to translate to. This will override values found
 in the LANG and LANGUAGE environment variables.}
+
+\item{.context_size}{Maximum number of words for the context summary that is
+prepended to every field's translation prompt. Set to \code{0} to disable
+context-aware translation. Defaults to \code{100}.}
 
 \item{.silent}{Boolean flag that controls if there is or not output to the
 console. Defaults to FALSE.}

--- a/site/knitr-print.R
+++ b/site/knitr-print.R
@@ -8,9 +8,9 @@ ctl_new_pillar.tbl_long <- function(controller, x, width, ...) {
   out <- NextMethod()
   max_width <- 90
   widths <- .env_knir_tbl$widths
-  if(sum(widths) > max_width) {
+  if (sum(widths) > max_width) {
     attr(out$data, "width") <- floor(max_width / 2)
-  } 
+  }
   new_pillar(list(
     title = out$title,
     type = out$type,
@@ -19,13 +19,16 @@ ctl_new_pillar.tbl_long <- function(controller, x, width, ...) {
 }
 
 knit_print.data.frame = function(x, ...) {
-  .env_knir_tbl$widths <- map_int(x, \(y) max(nchar(as.character(y[!is.na(y)]))))
-  x <- new_tibble(x, class = "tbl_long") 
+  .env_knir_tbl$widths <- map_int(x, \(y) {
+    max(nchar(as.character(y[!is.na(y)])))
+  })
+  x <- new_tibble(x, class = "tbl_long")
   knitr::normal_print(x)
 }
 
 registerS3method(
-  "knit_print", "data.frame", knit_print.data.frame,
+  "knit_print",
+  "data.frame",
+  knit_print.data.frame,
   envir = asNamespace("knitr")
 )
- 

--- a/tests/testthat/_snaps/lang-help.md
+++ b/tests/testthat/_snaps/lang-help.md
@@ -99,7 +99,7 @@
     Code
       lang_help("nothere", lang = "spanish", type = "text")
     Condition
-      Error in `lang_help()`:
+      Error in `rd_find()`:
       ! Could not find `nothere`
       i Tip: Make sure the containing package is loaded, and the topic is spelled correctly
 
@@ -108,7 +108,7 @@
     Code
       lang_help("nothere", "notpkg", lang = "spanish", type = "text")
     Condition
-      Error in `lang_help()`:
+      Error in `rd_find()`:
       ! Package `notpkg` not found
       i Tip: Make sure package name is spelled correctly
 
@@ -117,7 +117,7 @@
     Code
       lang_help("nothere", "mall", lang = "spanish", type = "text")
     Condition
-      Error in `lang_help()`:
+      Error in `rd_find()`:
       ! `nothere` could not be found in `mall`
       i Tip: Make sure both are spelled correctly
 

--- a/tests/testthat/test-help-shims.R
+++ b/tests/testthat/test-help-shims.R
@@ -2,7 +2,12 @@ skip_on_os("windows")
 
 test_that("shim_lang_help works", {
   invisible(
-    lang_use_impl("simulate_llm", "echo", .is_internal = TRUE, .lang = "spanish")
+    lang_use_impl(
+      "simulate_llm",
+      "echo",
+      .is_internal = TRUE,
+      .lang = "spanish"
+    )
   )
   expect_message(shim_lang_help(NULL))
   expect_message(shim_lang_help(NULL, base))
@@ -14,7 +19,12 @@ test_that("shim_lang_help works", {
   expect_message(shim_lang_help(mtcars, datasets))
   expect_message(shim_lang_help("mtcars", "datasets"))
   invisible(
-    lang_use_impl("simulate_llm", "echo", .is_internal = TRUE, .lang = "english")
+    lang_use_impl(
+      "simulate_llm",
+      "echo",
+      .is_internal = TRUE,
+      .lang = "english"
+    )
   )
   expect_silent(shim_lang_help(mtcars))
 })
@@ -57,7 +67,12 @@ test_that("shim_lang_question works", {
     list(help_type = "text"),
     {
       invisible(
-        lang_use_impl("simulate_llm", "echo", .is_internal = TRUE, .lang = "spanish")
+        lang_use_impl(
+          "simulate_llm",
+          "echo",
+          .is_internal = TRUE,
+          .lang = "spanish"
+        )
       )
       expect_message(shim_lang_question(lm))
       expect_message(shim_lang_question(datasets::mtcars))

--- a/tests/testthat/test-lang-use.R
+++ b/tests/testthat/test-lang-use.R
@@ -45,6 +45,6 @@ test_that("lang_use() works with disabled cache", {
 test_that("Warning is displayed if .lang_chat is set", {
   withr::with_options(
     list(.lang_chat = 3),
-    expect_warning(lang_use())
+    expect_warning(lang_use(.silent = TRUE))
   )
 })

--- a/tests/testthat/test-lang-use.R
+++ b/tests/testthat/test-lang-use.R
@@ -26,7 +26,13 @@ test_that("lang_use() works with ellmer", {
 
 test_that("lang_use() works with additional arguments", {
   expect_snapshot(
-    lang_use("simulate_llm", "echo", temp = 0.8, .cache = "path/to/cache", .lang = "test")
+    lang_use(
+      "simulate_llm",
+      "echo",
+      temp = 0.8,
+      .cache = "path/to/cache",
+      .lang = "test"
+    )
   )
 })
 

--- a/tests/testthat/test-rd-translate.R
+++ b/tests/testthat/test-rd-translate.R
@@ -4,8 +4,8 @@ test_that("Progress bar functions run without error", {
   )
   suppressMessages({
     expect_no_error(progress_bar_init(10L, ""))
-    expect_no_error(progress_bar_update("Label"))
-    expect_no_error(progress_bar_update("Label", done = TRUE))
+    expect_no_error(progress_bar_update_text("Label"))
+    expect_no_error(progress_bar_update_done("some result"))
   })
 })
 

--- a/tests/testthat/test-rd-translate.R
+++ b/tests/testthat/test-rd-translate.R
@@ -1,12 +1,12 @@
-test_that("Progress messages work", {
+test_that("Progress bar functions run without error", {
   local_mocked_bindings(
     is_interactive = function(...) TRUE
   )
-  new_obj <- list(1:1000)
-  expect_silent(progress_bar_init(object.size(new_obj), ""))
-  expect_silent(progress_bar_update(10))
-  expect_silent(progress_bar_update(obj = list(1:10)))
-  expect_silent(progress_bar_update(obj = new_obj))
+  suppressMessages({
+    expect_no_error(progress_bar_init(10L, ""))
+    expect_no_error(progress_bar_update("Label"))
+    expect_no_error(progress_bar_update("Label", done = TRUE))
+  })
 })
 
 # ---- rd_flatten ---------------------------------------------------------------
@@ -62,7 +62,7 @@ test_that("rd_flatten returns empty string for empty list", {
 
 # ---- rd_count_fields ---------------------------------------------------------
 
-test_that("rd_count_fields adds 2 when context_size >= 1", {
+test_that("rd_count_fields counts fields correctly", {
   lst <- list(
     title = "T",
     description = "D",
@@ -70,14 +70,7 @@ test_that("rd_count_fields adds 2 when context_size >= 1", {
       list(argument = "x", description = "desc")
     )
   )
-  base_count <- rd_count_fields(lst, context_size = 0L)
-  context_count <- rd_count_fields(lst, context_size = 100L)
-  expect_equal(context_count, base_count + 2L)
-})
-
-test_that("rd_count_fields does not add 2 when context_size is 0", {
-  lst <- list(title = "T")
-  expect_equal(rd_count_fields(lst, context_size = 0L), 1L)
+  expect_equal(rd_count_fields(lst), 3L)
 })
 
 # ---- rd_field_translate context block ----------------------------------------

--- a/tests/testthat/test-rd-translate.R
+++ b/tests/testthat/test-rd-translate.R
@@ -8,3 +8,111 @@ test_that("Progress messages work", {
   expect_silent(progress_bar_update(obj = list(1:10)))
   expect_silent(progress_bar_update(obj = new_obj))
 })
+
+# ---- rd_flatten ---------------------------------------------------------------
+
+test_that("rd_flatten emits [[markers]] for prose fields", {
+  lst <- list(
+    title = "My Function",
+    description = c("Does something", "useful.")
+  )
+  out <- rd_flatten(lst)
+  expect_true(grepl("[[title]]", out, fixed = TRUE))
+  expect_true(grepl("My Function", out, fixed = TRUE))
+  expect_true(grepl("[[description]]", out, fixed = TRUE))
+  expect_true(grepl("Does something", out, fixed = TRUE))
+})
+
+test_that("rd_flatten emits argument markers without a section header", {
+  lst <- list(
+    arguments = list(
+      list(argument = "x", description = "A data frame"),
+      list(argument = "n", description = "Number of rows")
+    )
+  )
+  out <- rd_flatten(lst)
+  expect_true(grepl("[[x]]", out, fixed = TRUE))
+  expect_true(grepl("A data frame", out, fixed = TRUE))
+  expect_true(grepl("[[n]]", out, fixed = TRUE))
+  expect_false(grepl("[[arguments]]", out, fixed = TRUE))
+})
+
+test_that("rd_flatten handles value with intro, components, and outro", {
+  lst <- list(
+    value = list(
+      intro = "A list with:",
+      components = list(
+        list(component = "result", description = "The output"),
+        list(component = "info", description = "Metadata")
+      ),
+      outro = "See details."
+    )
+  )
+  out <- rd_flatten(lst)
+  expect_true(grepl("[[value.intro]]", out, fixed = TRUE))
+  expect_true(grepl("A list with:", out, fixed = TRUE))
+  expect_true(grepl("[[result]]", out, fixed = TRUE))
+  expect_true(grepl("[[value.outro]]", out, fixed = TRUE))
+  expect_true(grepl("See details.", out, fixed = TRUE))
+})
+
+test_that("rd_flatten returns empty string for empty list", {
+  expect_equal(rd_flatten(list()), "")
+})
+
+# ---- rd_count_fields ---------------------------------------------------------
+
+test_that("rd_count_fields adds 2 when context_size >= 1", {
+  lst <- list(
+    title = "T",
+    description = "D",
+    arguments = list(
+      list(argument = "x", description = "desc")
+    )
+  )
+  base_count <- rd_count_fields(lst, context_size = 0L)
+  context_count <- rd_count_fields(lst, context_size = 100L)
+  expect_equal(context_count, base_count + 2L)
+})
+
+test_that("rd_count_fields does not add 2 when context_size is 0", {
+  lst <- list(title = "T")
+  expect_equal(rd_count_fields(lst, context_size = 0L), 1L)
+})
+
+# ---- rd_field_translate context block ----------------------------------------
+
+test_that("rd_field_translate prepends context block when context_summary is set", {
+  # Capture the add_prompt passed to llm_vec_translate by running with echo LLM
+  invisible(
+    lang_use_impl("simulate_llm", "echo", .is_internal = TRUE)
+  )
+  rs <- callr::r_session$new()
+  on.exit(rs$close())
+  lang_args <- lang_use_impl(.is_internal = TRUE)
+  rs$run(
+    function(x) rlang::exec(mall::llm_use, !!!x),
+    args = list(
+      x = list(
+        backend = lang_args[["backend"]],
+        model = lang_args[["model"]],
+        .cache = lang_args[[".cache"]]
+      )
+    )
+  )
+  result_with <- rd_field_translate(
+    "hello",
+    "spanish",
+    rs,
+    context_summary = "A short summary"
+  )
+  result_without <- rd_field_translate(
+    "hello",
+    "spanish",
+    rs,
+    context_summary = NULL
+  )
+  # echo LLM returns input unchanged; both calls succeed without error
+  expect_type(result_with, "character")
+  expect_type(result_without, "character")
+})

--- a/utils/prep-codes.R
+++ b/utils/prep-codes.R
@@ -2,29 +2,29 @@ library(tidyverse)
 
 iso <- read_csv("utils/iso_639-1.csv")
 
-codes <- iso |> 
+codes <- iso |>
   mutate(
     name = str_to_lower(name),
     code = `639-1`
-  ) |> 
+  ) |>
   select(name, code)
 
-clean_codes <- codes |> 
-  mutate(name = str_replace(name, "\\(farsi\\)", ", farsi")) |> 
-  mutate(name = str_remove(name, "\\(tonga islands\\)")) |> 
-  mutate(name = str_remove(name, "\\(saṁskṛta\\)")) |> 
-  mutate(name = str_remove(name, "\\(eastern\\)")) |> 
-  mutate(name = str_remove(name, "\\(marāṭhī\\)")) |> 
-  separate_longer_delim(name, ",") |> 
-  mutate(name = str_remove(name, "\\(modern\\)")) |> 
-  mutate(name = str_remove(name, "standard")) |> 
-  mutate(name = str_trim(name)) |> 
-  arrange(code) |> 
-  group_by(name, code) |> 
-  summarise() |> 
-  group_by(code) |> 
-  mutate(number = row_number()) |> 
-  ungroup() |> 
+clean_codes <- codes |>
+  mutate(name = str_replace(name, "\\(farsi\\)", ", farsi")) |>
+  mutate(name = str_remove(name, "\\(tonga islands\\)")) |>
+  mutate(name = str_remove(name, "\\(saṁskṛta\\)")) |>
+  mutate(name = str_remove(name, "\\(eastern\\)")) |>
+  mutate(name = str_remove(name, "\\(marāṭhī\\)")) |>
+  separate_longer_delim(name, ",") |>
+  mutate(name = str_remove(name, "\\(modern\\)")) |>
+  mutate(name = str_remove(name, "standard")) |>
+  mutate(name = str_trim(name)) |>
+  arrange(code) |>
+  group_by(name, code) |>
+  summarise() |>
+  group_by(code) |>
+  mutate(number = row_number()) |>
+  ungroup() |>
   arrange(code)
 
 write_rds(clean_codes, "inst/iso/codes.rds")

--- a/utils/sections.R
+++ b/utils/sections.R
@@ -2,19 +2,29 @@ unnused_tags <- function(pkg) {
   db <- tools::Rd_db(pkg)
   topics <- fs::path_ext_remove(names(db))
   tags <- c(
-    "\\title", "\\description", "\\value",
-    "\\details", "\\seealso", "\\note", "\\author",
-    "\\section", "\\arguments", "\\examples", 
-    "\\name", "\\alias", "\\keyword", "\\usage",
+    "\\title",
+    "\\description",
+    "\\value",
+    "\\details",
+    "\\seealso",
+    "\\note",
+    "\\author",
+    "\\section",
+    "\\arguments",
+    "\\examples",
+    "\\name",
+    "\\alias",
+    "\\keyword",
+    "\\usage",
     "\\references"
   )
-  for(topic in db) {
+  for (topic in db) {
     all_tags <- as.character(lapply(topic, function(x) attr(x, "Rd_tag")))
     dif <- setdiff(all_tags, tags)
-    if(length(dif) != 0) {
+    if (length(dif) != 0) {
       print(paste(as.character(topic[[2]]), "-", paste(dif, collapse = ", ")))
     }
-  }  
+  }
 }
 
 unnused_tags("ggplot2")


### PR DESCRIPTION
1. **Fixed the progress bar** — switched from byte-size tracking to field-count,
   then back to size-based with `progress_bar_update_done(obj)`, split the single
   `progress_bar_update()` into `progress_bar_update_text()` and
   `progress_bar_update_done()` for clarity, and simplified the total size
   calculation to `object.size(lst)` minus `examples` and `usage`.

2. **Cleaned up `rd_translate`** — moved it to the top of the file, removed the
   redundant `rd_trans_size()` function, consolidated `progress_bar_update_done()`
   calls to pass whole nodes instead of subcomponents, and improved all progress
   label wording (dashes instead of colons, consistent plurals, "Creating Context"
   instead of "Context").

3. **Extracted `rd_find()`** — pulled the Rd content lookup logic out of
   `lang_help()` into its own internal function, returning a list with `topic`,
   `package`, and `content`, making it independently callable for debugging.

4. **Improved the README** — added an explanation of the context feature and why
   it exists, added an `ellmer` example to the auto-initialize section, fixed all
   double spaces, duplicate badge, comma after "Llama3.2", "your your", moved the
   section-names caveat, and renamed "Debug" to "Debugging".

5. **Improved help documentation** — fixed grammar and typos across `lang-use.R`,
   `lang-help.R`, and `help-shims.R`, and rewrote several `@param` descriptions
   to be clearer (`.cache`, `.context_size`, `backend`, `topic`, and the shims
   description).